### PR TITLE
Support setting headers when connecting and reconnecting

### DIFF
--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -8,6 +8,8 @@ import FoundationNetworking
 import os.log
 #endif
 
+typealias HeaderTransform = ([String: String]) -> [String: String]
+
 public class EventSource {
     private let esDelegate: EventSourceDelegate
 
@@ -56,7 +58,7 @@ public class EventSource {
         /// Additional headers to be set on the request
         public var headers: [String: String] = [:]
         /// Provides the ability to add conditional headers
-        public var extraHeaders: ([String: String]) -> [String: String] = { $0 }
+        public var extraHeaders: HeaderTransform = { $0 }
         /// The minimum amount of time to wait before reconnecting after a failure
         public var reconnectTime: TimeInterval = 1.0
         /// The maximum amount of time to wait before reconnecting after a failure

--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -8,7 +8,7 @@ import FoundationNetworking
 import os.log
 #endif
 
-typealias HeaderTransform = ([String: String]) -> [String: String]
+public typealias HeaderTransform = ([String: String]) -> [String: String]
 
 public class EventSource {
     private let esDelegate: EventSourceDelegate

--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -55,6 +55,8 @@ public class EventSource {
         public var lastEventId: String? = nil
         /// Additional headers to be set on the request
         public var headers: [String: String] = [:]
+        /// Provides the ability to add conditional headers
+        public var extraHeaders: ([String: String]) -> [String: String] = { $0 }
         /// The minimum amount of time to wait before reconnecting after a failure
         public var reconnectTime: TimeInterval = 1.0
         /// The maximum amount of time to wait before reconnecting after a failure
@@ -144,7 +146,9 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
         urlRequest.httpMethod = self.config.method
         urlRequest.httpBody = self.config.body
         urlRequest.setValue(self.lastEventId, forHTTPHeaderField: "Last-Event-ID")
-        urlRequest.allHTTPHeaderFields?.merge(self.config.headers, uniquingKeysWith: { $1 })
+        urlRequest.allHTTPHeaderFields = self.config.extraHeaders(
+            urlRequest.allHTTPHeaderFields?.merging(self.config.headers) { $1 } ?? self.config.headers
+        )
         let task = session.dataTask(with: urlRequest)
         task.resume()
         sessionTask = task

--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -8,8 +8,6 @@ import FoundationNetworking
 import os.log
 #endif
 
-public typealias HeaderTransform = ([String: String]) -> [String: String]
-
 public class EventSource {
     private let esDelegate: EventSourceDelegate
 
@@ -58,7 +56,7 @@ public class EventSource {
         /// Additional headers to be set on the request
         public var headers: [String: String] = [:]
         /// Provides the ability to add conditional headers
-        public var extraHeaders: HeaderTransform = { $0 }
+        public var headerTransform: HeaderTransform = { $0 }
         /// The minimum amount of time to wait before reconnecting after a failure
         public var reconnectTime: TimeInterval = 1.0
         /// The maximum amount of time to wait before reconnecting after a failure
@@ -148,7 +146,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
         urlRequest.httpMethod = self.config.method
         urlRequest.httpBody = self.config.body
         urlRequest.setValue(self.lastEventId, forHTTPHeaderField: "Last-Event-ID")
-        urlRequest.allHTTPHeaderFields = self.config.extraHeaders(
+        urlRequest.allHTTPHeaderFields = self.config.headerTransform(
             urlRequest.allHTTPHeaderFields?.merging(self.config.headers) { $1 } ?? self.config.headers
         )
         let task = session.dataTask(with: urlRequest)

--- a/Source/Types.swift
+++ b/Source/Types.swift
@@ -5,6 +5,11 @@ import Foundation
 /// it has the ability to tell EventSource to stop reconnecting.
 public typealias ConnectionErrorHandler = (Error) -> ConnectionErrorAction
 
+/// Type for a function that will take in the current http headers
+/// and return a new set of http headers to be used when connecting
+/// and reconnecting to a stream.
+public typealias HeaderTransform = ([String: String]) -> [String: String]
+
 /// Potential actions a ConnectionErrorHandler can return
 public enum ConnectionErrorAction {
     /// Specifies that the error should be logged normally and dispatched to the EventHandler.

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -29,7 +29,7 @@ final class LDSwiftEventSourceTests: XCTestCase {
         config.body = testBody
         config.lastEventId = "eventId"
         config.headers = testHeaders
-        config.extraHeaders = { _ in [:] }
+        config.headerTransform = { _ in [:] }
         config.reconnectTime = 2.0
         config.maxReconnectTime = 60.0
         config.backoffResetThreshold = 120.0
@@ -40,7 +40,7 @@ final class LDSwiftEventSourceTests: XCTestCase {
         XCTAssertEqual(config.body, testBody)
         XCTAssertEqual(config.lastEventId, "eventId")
         XCTAssertEqual(config.headers, testHeaders)
-        XCTAssertEqual(config.extraHeaders(config.headers), [:])
+        XCTAssertEqual(config.headerTransform(config.headers), [:])
         XCTAssertEqual(config.reconnectTime, 2.0)
         XCTAssertEqual(config.maxReconnectTime, 60.0)
         XCTAssertEqual(config.backoffResetThreshold, 120.0)

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -29,6 +29,7 @@ final class LDSwiftEventSourceTests: XCTestCase {
         config.body = testBody
         config.lastEventId = "eventId"
         config.headers = testHeaders
+        config.extraHeaders = { _ in [:] }
         config.reconnectTime = 2.0
         config.maxReconnectTime = 60.0
         config.backoffResetThreshold = 120.0
@@ -39,6 +40,7 @@ final class LDSwiftEventSourceTests: XCTestCase {
         XCTAssertEqual(config.body, testBody)
         XCTAssertEqual(config.lastEventId, "eventId")
         XCTAssertEqual(config.headers, testHeaders)
+        XCTAssertEqual(config.extraHeaders(config.headers), [:])
         XCTAssertEqual(config.reconnectTime, 2.0)
         XCTAssertEqual(config.maxReconnectTime, 60.0)
         XCTAssertEqual(config.backoffResetThreshold, 120.0)


### PR DESCRIPTION
**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [X] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

Added a closure to the config that is invoked when configuring headers at connect and reconnect events.

**Additional context**

This is required to support lazily setting headers in our swift sdk.