### PR TITLE
Respect error handler's action for unsuccessful response errors

### DIFF
--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -249,6 +249,10 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
             os_log("Unsuccessful response: %d", log: logger, type: .info, httpResponse.statusCode)
             #endif
             errorHandlerAction = dispatchError(error: UnsuccessfulResponseError(responseCode: httpResponse.statusCode))
+
+            if errorHandlerAction == .shutdown {
+                readyState = .shutdown
+            }
             completionHandler(.cancel)
         }
     }


### PR DESCRIPTION
### Previous behavior
For `UnsuccessfulResponseError`, the error handler is consulted but its action is never used. The data task is then cancelled, leading to a `URLError.cancelled` error, and the error handler's action for _this error_ is what is used for deciding the behavior. This is probably not what anyone expects or wants.

### New behavior
If the error handler returns `.shutdown` for unsuccessful response errors, we set `readyState` to `.shutdown`. The error handler never gets the `URLError.cancelled` error and `afterComplete()` shuts down.