### PR TITLE
Reset connectedTime to fix backoff reset behavior

### DIFF
--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -191,6 +191,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
         if let connectedTime = connectedTime, Date().timeIntervalSince(connectedTime) >= config.backoffResetThreshold {
             reconnectionAttempts = 0
         }
+        self.connectedTime = nil
 
         let maxSleep = min(config.maxReconnectTime, reconnectTime * pow(2.0, Double(reconnectionAttempts)))
         let sleep = maxSleep / 2 + Double.random(in: 0...(maxSleep/2))


### PR DESCRIPTION
### Previous behavior
If `backoffResetThreshold` seconds have passed since the last successful connection, the backoff is reset, regardless of whether this is the first reconnection attempt or not, and no further backoff is performed since it gets reset for every attempt.

### New behavior
The reset threshold is only considered for the first reconnection attempt after a successful connection, as you would expect.