### PR TITLE
Improve `stop()` behavior and test coverage.

### DIFF
--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -112,6 +112,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
     private let utf8LineParser: UTF8LineParser = UTF8LineParser()
     // swiftlint:disable:next implicitly_unwrapped_optional
     private var eventParser: EventParser!
+    private var urlSession: URLSession?
     private var sessionTask: URLSessionDataTask?
 
     init(config: EventSource.Config) {
@@ -129,19 +130,41 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
                 #endif
                 return
             }
+            self.urlSession = self.createSession()
             self.connect()
         }
     }
 
     func stop() {
+        let previousState = readyState
+        readyState = .shutdown
         sessionTask?.cancel()
-        if readyState == .open {
+        if previousState == .open {
             config.handler.onClosed()
         }
-        readyState = .shutdown
     }
 
     func getLastEventId() -> String? { lastEventId }
+
+    func createSession() -> URLSession {
+        let sessionConfig = URLSessionConfiguration.default
+        sessionConfig.httpAdditionalHeaders = ["Accept": "text/event-stream", "Cache-Control": "no-cache"]
+        sessionConfig.timeoutIntervalForRequest = self.config.idleTimeout
+        return URLSession(configuration: sessionConfig, delegate: self, delegateQueue: nil)
+    }
+
+    func createRequest() -> URLRequest {
+        var urlRequest = URLRequest(url: self.config.url,
+                                    cachePolicy: URLRequest.CachePolicy.reloadIgnoringLocalAndRemoteCacheData,
+                                    timeoutInterval: self.config.idleTimeout)
+        urlRequest.httpMethod = self.config.method
+        urlRequest.httpBody = self.config.body
+        urlRequest.setValue(self.lastEventId, forHTTPHeaderField: "Last-Event-ID")
+        urlRequest.allHTTPHeaderFields = self.config.headerTransform(
+            urlRequest.allHTTPHeaderFields?.merging(self.config.headers) { $1 } ?? self.config.headers
+        )
+        return urlRequest
+    }
 
     private func connect() {
         #if !os(Linux)
@@ -152,25 +175,12 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
             setLastEventId: { eventId in self.lastEventId = eventId }
         )
         self.eventParser = EventParser(handler: self.config.handler, connectionHandler: connectionHandler)
-        let sessionConfig = URLSessionConfiguration.default
-        sessionConfig.httpAdditionalHeaders = ["Accept": "text/event-stream", "Cache-Control": "no-cache"]
-        sessionConfig.timeoutIntervalForRequest = self.config.idleTimeout
-        let session = URLSession(configuration: sessionConfig, delegate: self, delegateQueue: nil)
-        var urlRequest = URLRequest(url: self.config.url,
-                                    cachePolicy: URLRequest.CachePolicy.reloadIgnoringLocalAndRemoteCacheData,
-                                    timeoutInterval: self.config.idleTimeout)
-        urlRequest.httpMethod = self.config.method
-        urlRequest.httpBody = self.config.body
-        urlRequest.setValue(self.lastEventId, forHTTPHeaderField: "Last-Event-ID")
-        urlRequest.allHTTPHeaderFields = self.config.headerTransform(
-            urlRequest.allHTTPHeaderFields?.merging(self.config.headers) { $1 } ?? self.config.headers
-        )
-        let task = session.dataTask(with: urlRequest)
-        task.resume()
+        let task = urlSession?.dataTask(with: createRequest())
+        task?.resume()
         sessionTask = task
     }
 
-    private func dispatchError(error: Error) -> ConnectionErrorAction {
+    func dispatchError(error: Error) -> ConnectionErrorAction {
         let action: ConnectionErrorAction = config.connectionErrorHandler(error)
         if action != .shutdown {
             config.handler.onError(error: error)
@@ -179,6 +189,9 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
     }
 
     private func afterComplete() {
+        guard readyState != .shutdown
+        else { return }
+
         var nextState: ReadyState = .closed
         let currentState: ReadyState = readyState
         if errorHandlerAction == .shutdown {
@@ -217,6 +230,8 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
         }
     }
 
+    // MARK: URLSession Delegates
+
     // Tells the delegate that the task finished transferring data.
     public func urlSession(_ session: URLSession,
                            task: URLSessionTask,
@@ -226,7 +241,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
         eventParser.parse(line: "")
 
         if let error = error {
-            if readyState != .shutdown {
+            if readyState != .shutdown && errorHandlerAction != .shutdown {
                 #if !os(Linux)
                 os_log("Connection error: %@", log: logger, type: .info, error.localizedDescription)
                 #endif
@@ -252,6 +267,12 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
         os_log("initial reply received", log: logger, type: .debug)
         #endif
 
+        guard readyState != .shutdown
+        else {
+            completionHandler(.cancel)
+            return
+        }
+
         // swiftlint:disable:next force_cast
         let httpResponse = response as! HTTPURLResponse
         if (200..<300).contains(httpResponse.statusCode) {
@@ -264,10 +285,6 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
             os_log("Unsuccessful response: %d", log: logger, type: .info, httpResponse.statusCode)
             #endif
             errorHandlerAction = dispatchError(error: UnsuccessfulResponseError(responseCode: httpResponse.statusCode))
-
-            if errorHandlerAction == .shutdown {
-                readyState = .shutdown
-            }
             completionHandler(.cancel)
         }
     }

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -3,9 +3,8 @@ import XCTest
 
 final class LDSwiftEventSourceTests: XCTestCase {
     func testConfigDefaults() {
-        let handler = MockHandler()
         let url = URL(string: "abc")!
-        let config = EventSource.Config(handler: handler, url: url)
+        let config = EventSource.Config(handler: MockHandler(), url: url)
         XCTAssertEqual(config.url, url)
         XCTAssertEqual(config.method, "GET")
         XCTAssertEqual(config.body, nil)
@@ -15,12 +14,13 @@ final class LDSwiftEventSourceTests: XCTestCase {
         XCTAssertEqual(config.maxReconnectTime, 30.0)
         XCTAssertEqual(config.backoffResetThreshold, 60.0)
         XCTAssertEqual(config.idleTimeout, 300.0)
+        XCTAssertEqual(config.headerTransform(["abc": "123"]), ["abc": "123"])
+        XCTAssertEqual(config.connectionErrorHandler(DummyError()), .proceed)
     }
 
     func testConfigModification() {
-        let handler = MockHandler()
         let url = URL(string: "abc")!
-        var config = EventSource.Config(handler: handler, url: url)
+        var config = EventSource.Config(handler: MockHandler(), url: url)
 
         let testBody = "test data".data(using: .utf8)
         let testHeaders = ["Authorization": "basic abc"]
@@ -29,11 +29,12 @@ final class LDSwiftEventSourceTests: XCTestCase {
         config.body = testBody
         config.lastEventId = "eventId"
         config.headers = testHeaders
-        config.headerTransform = { _ in [:] }
         config.reconnectTime = 2.0
         config.maxReconnectTime = 60.0
         config.backoffResetThreshold = 120.0
         config.idleTimeout = 180.0
+        config.headerTransform = { _ in [:] }
+        config.connectionErrorHandler = { _ in .shutdown }
 
         XCTAssertEqual(config.url, url)
         XCTAssertEqual(config.method, "REPORT")
@@ -45,22 +46,129 @@ final class LDSwiftEventSourceTests: XCTestCase {
         XCTAssertEqual(config.maxReconnectTime, 60.0)
         XCTAssertEqual(config.backoffResetThreshold, 120.0)
         XCTAssertEqual(config.idleTimeout, 180.0)
+        XCTAssertEqual(config.connectionErrorHandler(DummyError()), .shutdown)
+    }
+
+    func testLastEventIdFromConfig() {
+        var config = EventSource.Config(handler: MockHandler(), url: URL(string: "abc")!)
+        var es = EventSource(config: config)
+        XCTAssertEqual(es.getLastEventId(), nil)
+        config.lastEventId = "def"
+        es = EventSource(config: config)
+        XCTAssertEqual(es.getLastEventId(), "def")
+    }
+
+    func testCreatedSession() {
+        let config = EventSource.Config(handler: MockHandler(), url: URL(string: "abc")!)
+        let session = EventSourceDelegate(config: config).createSession()
+        XCTAssertEqual(session.configuration.timeoutIntervalForRequest, config.idleTimeout)
+        XCTAssertEqual(session.configuration.httpAdditionalHeaders?["Accept"] as? String, "text/event-stream")
+        XCTAssertEqual(session.configuration.httpAdditionalHeaders?["Cache-Control"] as? String, "no-cache")
+    }
+
+    func testCreateRequest() {
+        // 192.0.2.1 is assigned as TEST-NET-1 reserved usage.
+        var config = EventSource.Config(handler: MockHandler(), url: URL(string: "http://192.0.2.1")!)
+        // Testing default configs
+        var request = EventSourceDelegate(config: config).createRequest()
+        XCTAssertEqual(request.url, config.url)
+        XCTAssertEqual(request.httpMethod, config.method)
+        XCTAssertEqual(request.httpBody, config.body)
+        XCTAssertEqual(request.timeoutInterval, config.idleTimeout)
+        XCTAssertEqual(request.allHTTPHeaderFields, config.headers)
+        // Testing customized configs
+        let testBody = "test data".data(using: .utf8)
+        let testHeaders = ["removing": "a", "updating": "b"]
+        let overrideHeaders = ["updating": "c", "last-event-id": "eventId2"]
+        config.method = "REPORT"
+        config.body = testBody
+        config.lastEventId = "eventId"
+        config.headers = testHeaders
+        config.idleTimeout = 180.0
+        config.headerTransform = { provided in
+            XCTAssertEqual(provided, ["removing": "a", "updating": "b", "Last-Event-ID": "eventId"])
+            return overrideHeaders
+        }
+        request = EventSourceDelegate(config: config).createRequest()
+        XCTAssertEqual(request.url, config.url)
+        XCTAssertEqual(request.httpMethod, config.method)
+        XCTAssertEqual(request.httpBody, config.body)
+        XCTAssertEqual(request.timeoutInterval, config.idleTimeout)
+        XCTAssertEqual(request.allHTTPHeaderFields, overrideHeaders)
+    }
+
+    func testDispatchError() {
+        let handler = MockHandler()
+        var connectionErrorHandlerCallCount = 0
+        var connectionErrorAction: ConnectionErrorAction = .proceed
+        var config = EventSource.Config(handler: handler, url: URL(string: "abc")!)
+        config.connectionErrorHandler = { error in
+            connectionErrorHandlerCallCount += 1
+            return connectionErrorAction
+        }
+        let es = EventSourceDelegate(config: config)
+        XCTAssertEqual(es.dispatchError(error: DummyError()), .proceed)
+        XCTAssertEqual(connectionErrorHandlerCallCount, 1)
+        guard case .error(let err) = handler.takeEvent(), err is DummyError
+        else {
+            XCTFail("handler should receive error if EventSource is not shutting down")
+            return
+        }
+        XCTAssertTrue(handler.receivedEvents.isEmpty)
+        connectionErrorAction = .shutdown
+        XCTAssertEqual(es.dispatchError(error: DummyError()), .shutdown)
+        XCTAssertEqual(connectionErrorHandlerCallCount, 2)
+        XCTAssertTrue(handler.receivedEvents.isEmpty)
+    }
+}
+
+private enum ReceivedEvent: Equatable {
+    case opened, closed, message(String, MessageEvent), comment(String), error(Error)
+
+    static func == (lhs: ReceivedEvent, rhs: ReceivedEvent) -> Bool {
+        switch (lhs, rhs) {
+        case (.opened, .opened):
+            return true
+        case (.closed, .closed):
+            return true
+        case let (.message(typeLhs, eventLhs), .message(typeRhs, eventRhs)):
+            return typeLhs == typeRhs && eventLhs == eventRhs
+        case let (.comment(lhs), .comment(rhs)):
+            return lhs == rhs
+        case (.error, .error):
+            return true
+        default:
+            return false
+        }
     }
 }
 
 private class MockHandler: EventHandler {
+    var receivedEvents: [ReceivedEvent] = []
+
     func onOpened() {
+        receivedEvents.append(.opened)
     }
 
     func onClosed() {
+        receivedEvents.append(.closed)
     }
 
     func onMessage(eventType: String, messageEvent: MessageEvent) {
+        receivedEvents.append(.message(eventType, messageEvent))
     }
 
     func onComment(comment: String) {
+        receivedEvents.append(.comment(comment))
     }
 
     func onError(error: Error) {
+        receivedEvents.append(.error(error))
+    }
+
+    func takeEvent() -> ReceivedEvent {
+        receivedEvents.remove(at: 0)
     }
 }
+
+private class DummyError: Error { }


### PR DESCRIPTION
This should fix a race condition on shutting down the client, where sometimes the session delegate would get the cancellation before the client entered the shutdown state. It would then restart the client and re-enter an active state.