### PR TITLE
Fix leaking EventSourceDelegate and URLSession

### DIFF
--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -122,7 +122,8 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
     }
 
     func start() {
-        delegateQueue.async {
+        delegateQueue.async { [weak self] in
+            guard let self = self else { return }
             guard self.readyState == .raw
             else {
                 #if !os(Linux)
@@ -225,8 +226,8 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
         #if !os(Linux)
         os_log("Waiting %.3f seconds before reconnecting...", log: logger, type: .info, sleep)
         #endif
-        delegateQueue.asyncAfter(deadline: .now() + sleep) {
-            self.connect()
+        delegateQueue.asyncAfter(deadline: .now() + sleep) { [weak self] in
+            self?.connect()
         }
     }
 

--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -171,8 +171,8 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
         os_log("Starting EventSource client", log: logger, type: .info)
         #endif
         let connectionHandler: ConnectionHandler = (
-            setReconnectionTime: { reconnectionTime in self.reconnectTime = reconnectionTime },
-            setLastEventId: { eventId in self.lastEventId = eventId }
+            setReconnectionTime: { [weak self] reconnectionTime in self?.reconnectTime = reconnectionTime },
+            setLastEventId: { [weak self] eventId in self?.lastEventId = eventId }
         )
         eventParser = EventParser(handler: config.handler, connectionHandler: connectionHandler)
         let task = urlSession?.dataTask(with: createRequest())

--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -117,8 +117,8 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
 
     init(config: EventSource.Config) {
         self.config = config
-        self.lastEventId = config.lastEventId
-        self.reconnectTime = config.reconnectTime
+        lastEventId = config.lastEventId
+        reconnectTime = config.reconnectTime
     }
 
     func start() {
@@ -154,14 +154,14 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
     }
 
     func createRequest() -> URLRequest {
-        var urlRequest = URLRequest(url: self.config.url,
+        var urlRequest = URLRequest(url: config.url,
                                     cachePolicy: URLRequest.CachePolicy.reloadIgnoringLocalAndRemoteCacheData,
-                                    timeoutInterval: self.config.idleTimeout)
-        urlRequest.httpMethod = self.config.method
-        urlRequest.httpBody = self.config.body
-        urlRequest.setValue(self.lastEventId, forHTTPHeaderField: "Last-Event-ID")
-        urlRequest.allHTTPHeaderFields = self.config.headerTransform(
-            urlRequest.allHTTPHeaderFields?.merging(self.config.headers) { $1 } ?? self.config.headers
+                                    timeoutInterval: config.idleTimeout)
+        urlRequest.httpMethod = config.method
+        urlRequest.httpBody = config.body
+        urlRequest.setValue(lastEventId, forHTTPHeaderField: "Last-Event-ID")
+        urlRequest.allHTTPHeaderFields = config.headerTransform(
+            urlRequest.allHTTPHeaderFields?.merging(config.headers) { $1 } ?? config.headers
         )
         return urlRequest
     }
@@ -174,7 +174,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
             setReconnectionTime: { reconnectionTime in self.reconnectTime = reconnectionTime },
             setLastEventId: { eventId in self.lastEventId = eventId }
         )
-        self.eventParser = EventParser(handler: self.config.handler, connectionHandler: connectionHandler)
+        eventParser = EventParser(handler: config.handler, connectionHandler: connectionHandler)
         let task = urlSession?.dataTask(with: createRequest())
         task?.resume()
         sessionTask = task

--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -143,6 +143,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
         if previousState == .open {
             config.handler.onClosed()
         }
+        urlSession?.invalidateAndCancel()
     }
 
     func getLastEventId() -> String? { lastEventId }


### PR DESCRIPTION
**Requirements**

- [-] I have added test coverage for new or changed functionality
- [+] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests) (I ran `swift test`) 
- [-] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

I was looking for mem leaks today, and spot some coming from the EventSource here:
* leaking URLSessions (and everything that belongs to it, like certificates, ...)
* leaking the EventSourceDelegate class

To fix them:
* cleanup the EventSourceDelegate from not-required usage of `self` (it was mixed anyways, and only having the ones required helps a bit spotting `self`-captures
* fix ref-cycle `self -> eventParser -> ConnectionHandler -> self`
* fix URLSession not being cleaned up properly, which kept the delegate alive

**Describe alternatives you've considered**

n/a
