### PR TITLE
Add configuration for URLSessionConfiguration.

### DIFF
--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -182,7 +182,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
                                     timeoutInterval: self.config.idleTimeout)
         urlRequest.httpMethod = self.config.method
         urlRequest.httpBody = self.config.body
-        urlRequest.setValue(self.lastEventId, forHTTPHeaderField: "Last-Event-ID")
+        urlRequest.setValue(self.lastEventId, forHTTPHeaderField: "Last-Event-Id")
         urlRequest.allHTTPHeaderFields = self.config.headerTransform(
             urlRequest.allHTTPHeaderFields?.merging(self.config.headers) { $1 } ?? self.config.headers
         )

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -56,7 +56,7 @@ final class LDSwiftEventSourceTests: XCTestCase {
         XCTAssertEqual(defaultSessionConfig.httpAdditionalHeaders?["Accept"] as? String, "text/event-stream")
         XCTAssertEqual(defaultSessionConfig.httpAdditionalHeaders?["Cache-Control"] as? String, "no-cache")
         // Configuration should return a fresh session configuration each retrieval
-        XCTAssertNotIdentical(defaultSessionConfig, config.urlSessionConfiguration)
+        XCTAssertTrue(defaultSessionConfig !== config.urlSessionConfiguration)
         // Updating idleTimeout should effect session config
         config.idleTimeout = 600.0
         XCTAssertEqual(config.urlSessionConfiguration.timeoutIntervalForRequest, 600.0)
@@ -67,7 +67,7 @@ final class LDSwiftEventSourceTests: XCTestCase {
         XCTAssertTrue(config.urlSessionConfiguration.allowsCellularAccess)
         config.urlSessionConfiguration = sessionConfig
         XCTAssertFalse(config.urlSessionConfiguration.allowsCellularAccess)
-        XCTAssertNotIdentical(sessionConfig, config.urlSessionConfiguration)
+        XCTAssertTrue(sessionConfig !== config.urlSessionConfiguration)
     }
 
     func testLastEventIdFromConfig() {

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -107,7 +107,7 @@ final class LDSwiftEventSourceTests: XCTestCase {
         config.headers = testHeaders
         config.idleTimeout = 180.0
         config.headerTransform = { provided in
-            XCTAssertEqual(provided, ["removing": "a", "updating": "b", "Last-Event-ID": "eventId"])
+            XCTAssertEqual(provided, ["removing": "a", "updating": "b", "Last-Event-Id": "eventId"])
             return overrideHeaders
         }
         request = EventSourceDelegate(config: config).createRequest()

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -34,6 +34,11 @@ extension LDSwiftEventSourceTests {
     static let __allTests__LDSwiftEventSourceTests = [
         ("testConfigDefaults", testConfigDefaults),
         ("testConfigModification", testConfigModification),
+        ("testConfigUrlSession", testConfigUrlSession),
+        ("testCreatedSession", testCreatedSession),
+        ("testCreateRequest", testCreateRequest),
+        ("testDispatchError", testDispatchError),
+        ("testLastEventIdFromConfig", testLastEventIdFromConfig),
     ]
 }
 


### PR DESCRIPTION
Proposed as an alternative to https://github.com/launchdarkly/swift-eventsource/pull/22. The intent is to avoid certain unexpected behavior of embedding a `class` in a `struct`. We desire the `Config` to be immutable once given to the `EventSource`, if the `Config` holds a reference to a `class` the reference would be immutable, but the underlying object could be updated.

Without copying the `URLSessionConfiguration` two issues could arise if an application gives a `URLSessionConfiguration` that is also used to create `URLSession`s in the application.
  1. If the `EventSource` updates the configuration of the `URLSessionConfiguration`, the application may not be aware and have it's desired configuration for other `URLSession`s created after the modification overridden.
  2. If the application updates the `URLSessionConfiguration` after being given to the `EventSource`, the behavior of the `EventSource` could change between reconnections.

Note that we cannot copy the `URLCache`, `HTTPCookieStorage`, `protocolClasses`, or `URLCredentialStorage` within the `URLSessionConfiguration`, so these may still be shared externally from the copied instance.

The implementation here of copying the `URLSessionConfiguration` for both `get` and `set` is similar to the behavior of `URLSession` on most platforms, but not identical. `URLSession` does copy the `URLSessionConfiguration` when it's initialized, but does not when retrieved. However it does make an internal `struct` copy of the fields of the set `URLSessionConfiguration` which it uses for all it's internal behavior. This means you can still not effect the configuration using the retrieved `URLSessionConfiguration`, but the changes are visible after updating the retrieved `URLSessionConfiguration` if the configuration is retrieved again unlike this implementation. 