### PR TITLE
Add logging wrapper to centralize OS checks.

### DIFF
--- a/LDSwiftEventSource.xcodeproj/project.pbxproj
+++ b/LDSwiftEventSource.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		B49B5E5B24668031008BF867 /* LDSwiftEventSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49B5E4324667F43008BF867 /* LDSwiftEventSourceTests.swift */; };
 		B49B5E67246684B9008BF867 /* LDSwiftEventSource.h in Headers */ = {isa = PBXBuildFile; fileRef = B49B5E65246684B9008BF867 /* LDSwiftEventSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B49B5E72246C4796008BF867 /* LDSwiftEventSource.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B49B5DFC24667D41008BF867 /* LDSwiftEventSource.framework */; };
+		B4C29CC826FF743D008B6DE2 /* Logs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C29CC726FF743C008B6DE2 /* Logs.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -48,6 +49,7 @@
 		B49B5E6E2466875F008BF867 /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
 		B49B5E6F2466875F008BF867 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		B49B5E702466875F008BF867 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		B4C29CC726FF743C008B6DE2 /* Logs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logs.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +110,7 @@
 				B49B5E4724667F43008BF867 /* LDSwiftEventSource.swift */,
 				B49B5E65246684B9008BF867 /* LDSwiftEventSource.h */,
 				B495D4A7248652DF00AE9233 /* Types.swift */,
+				B4C29CC726FF743C008B6DE2 /* Logs.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -258,6 +261,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B49B5E4B24667F62008BF867 /* UTF8LineParser.swift in Sources */,
+				B4C29CC826FF743D008B6DE2 /* Logs.swift in Sources */,
 				B495D4A9248652DF00AE9233 /* Types.swift in Sources */,
 				B49B5E4C24667F62008BF867 /* EventParser.swift in Sources */,
 				B49B5E4D24667F62008BF867 /* LDSwiftEventSource.swift in Sources */,

--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -4,10 +4,6 @@ import Foundation
 import FoundationNetworking
 #endif
 
-#if !os(Linux)
-import os.log
-#endif
-
 /**
  Provides an EventSource client for consuming Server-Sent Events.
 
@@ -87,19 +83,14 @@ public class EventSource {
 }
 
 class EventSourceDelegate: NSObject, URLSessionDataDelegate {
-    #if !os(Linux)
-    private let logger: OSLog = OSLog(subsystem: "com.launchdarkly.swift-eventsource", category: "LDEventSource")
-    #endif
+    private let delegateQueue: DispatchQueue = DispatchQueue(label: "ESDelegateQueue")
+    private let logger = Logs()
 
     private let config: EventSource.Config
 
-    private let delegateQueue: DispatchQueue = DispatchQueue(label: "ESDelegateQueue")
-
     private var readyState: ReadyState = .raw {
         didSet {
-            #if !os(Linux)
-            os_log("State: %@ -> %@", log: logger, type: .debug, oldValue.rawValue, readyState.rawValue)
-            #endif
+            logger.log(.debug, "State: %@ -> %@", oldValue.rawValue, readyState.rawValue)
         }
     }
 
@@ -125,9 +116,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
         delegateQueue.async {
             guard self.readyState == .raw
             else {
-                #if !os(Linux)
-                os_log("start() called on already-started EventSource object. Returning", log: self.logger, type: .info)
-                #endif
+                self.logger.log(.info, "start() called on already-started EventSource object. Returning")
                 return
             }
             self.urlSession = self.createSession()
@@ -167,9 +156,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
     }
 
     private func connect() {
-        #if !os(Linux)
-        os_log("Starting EventSource client", log: logger, type: .info)
-        #endif
+        logger.log(.info, "Starting EventSource client")
         let connectionHandler: ConnectionHandler = (
             setReconnectionTime: { reconnectionTime in self.reconnectTime = reconnectionTime },
             setLastEventId: { eventId in self.lastEventId = eventId }
@@ -195,9 +182,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
         var nextState: ReadyState = .closed
         let currentState: ReadyState = readyState
         if errorHandlerAction == .shutdown {
-            #if !os(Linux)
-            os_log("Connection has been explicitly shut down by error handler", log: logger, type: .info)
-            #endif
+            logger.log(.info, "Connection has been explicitly shut down by error handler")
             nextState = .shutdown
         }
         readyState = nextState
@@ -222,9 +207,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
         let maxSleep = min(config.maxReconnectTime, reconnectTime * pow(2.0, Double(reconnectionAttempts)))
         let sleep = maxSleep / 2 + Double.random(in: 0...(maxSleep / 2))
 
-        #if !os(Linux)
-        os_log("Waiting %.3f seconds before reconnecting...", log: logger, type: .info, sleep)
-        #endif
+        logger.log(.info, "Waiting %.3f seconds before reconnecting...", sleep)
         delegateQueue.asyncAfter(deadline: .now() + sleep) {
             self.connect()
         }
@@ -242,17 +225,13 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
 
         if let error = error {
             if readyState != .shutdown && errorHandlerAction != .shutdown {
-                #if !os(Linux)
-                os_log("Connection error: %@", log: logger, type: .info, error.localizedDescription)
-                #endif
+                logger.log(.info, "Connection error: %@", error.localizedDescription)
                 errorHandlerAction = dispatchError(error: error)
             } else {
                 errorHandlerAction = .shutdown
             }
         } else {
-            #if !os(Linux)
-            os_log("Connection unexpectedly closed.", log: logger, type: .info)
-            #endif
+            logger.log(.info, "Connection unexpectedly closed.")
         }
 
         afterComplete()
@@ -263,9 +242,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
                            dataTask: URLSessionDataTask,
                            didReceive response: URLResponse,
                            completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
-        #if !os(Linux)
-        os_log("initial reply received", log: logger, type: .debug)
-        #endif
+        logger.log(.debug, "Initial reply received")
 
         guard readyState != .shutdown
         else {
@@ -281,9 +258,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
             config.handler.onOpened()
             completionHandler(.allow)
         } else {
-            #if !os(Linux)
-            os_log("Unsuccessful response: %d", log: logger, type: .info, httpResponse.statusCode)
-            #endif
+            logger.log(.info, "Unsuccessful response: %d", httpResponse.statusCode)
             errorHandlerAction = dispatchError(error: UnsuccessfulResponseError(responseCode: httpResponse.statusCode))
             completionHandler(.cancel)
         }

--- a/Source/Logs.swift
+++ b/Source/Logs.swift
@@ -17,7 +17,9 @@ class Logs {
         #endif
     }
 
+    #if !os(Linux)
     private let logger: OSLog = OSLog(subsystem: "com.launchdarkly.swift-eventsource", category: "LDEventSource")
+    #endif
 
     func log(_ level: Level, _ staticMsg: StaticString, _ args: CVarArg...) {
         #if !os(Linux)

--- a/Source/Logs.swift
+++ b/Source/Logs.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+#if !os(Linux)
+import os.log
+#endif
+
+class Logs {
+    enum Level {
+        case debug, info, warn, error
+
+        #if !os(Linux)
+        private static let osLogTypes = [ Level.debug: OSLogType.debug,
+                                          Level.info: OSLogType.info,
+                                          Level.warn: OSLogType.default,
+                                          Level.error: OSLogType.error]
+        var osLogType: OSLogType { Level.osLogTypes[self]! }
+        #endif
+    }
+
+    private let logger: OSLog = OSLog(subsystem: "com.launchdarkly.swift-eventsource", category: "LDEventSource")
+
+    func log(_ level: Level, _ staticMsg: StaticString, _ args: CVarArg...) {
+        #if !os(Linux)
+        os_log(staticMsg, log: logger, type: level.osLogType, args)
+        #endif
+    }
+}


### PR DESCRIPTION
We may well want to write a generalized LaunchDarkly logging wrapper for Swift platforms at some point to share between the iOS SDK, this library, and anything else Swift we end up having.

This is just an _extremely_ basic wrapper to handle the `#if !os(Linux)` checks from polluting the library logic. We can extend it later if we want.