### PR TITLE
Improve CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
                 gem install jazzy
                 gem cleanup
                 # Used as cache key to prevent storing redundant caches
-                gem list > /tmp/cache_key.txt
+                gem list > /tmp/cache-key.txt
 
           - save_cache:
               key: v1-gem-cache-<<parameters.xcode-version>>-{{ checksum "/tmp/cache-key.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
         condition: <<parameters.build-doc>>
         steps:
           - restore_cache:
-              key: v1-gem-cache-<<parameters.xcode-version>>
+              key: v1-gem-cache-<<parameters.xcode-version>>-
 
           - run:
               name: Install jazzy gem

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ workflows:
       - build:
           name: Xcode 13.1 - Swift 5.5
           xcode-version: '13.1.0'
-          ios-sim: 'platform=iOS Simulator,name=iPhone 11,OS=15.1'
+          ios-sim: 'platform=iOS Simulator,name=iPhone 11,OS=15.0'
           build-doc: true
       - build:
           name: Xcode 12.5 - Swift 5.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ jobs:
         type: string
       ios-sim:
         type: string
+      build-universal:
+        type: boolean
+        default: true
       build-doc:
         type: boolean
         default: false
@@ -30,6 +33,14 @@ jobs:
         name: Build & Test on macOS Simulator
         command: xcodebuild test -scheme 'LDSwiftEventSource' -sdk macosx -destination 'platform=macOS' | tee 'artifacts/raw-logs-macosx.txt' | xcpretty -r junit -o 'test-results/platform-macosx/junit.xml'
         when: always
+
+    - when:
+        condition: <<parameters.build-universal>>
+        steps:
+          - run:
+              name: Build for ARM64 macOS
+              command: xcodebuild build -scheme 'LDSwiftEventSource' -arch arm64e -sdk macosx | tee 'artifacts/raw-logs-macosx-arm64e.txt' | xcpretty
+              when: always
 
     - run:
         name: Build Tests for iOS device
@@ -86,35 +97,6 @@ jobs:
     - store_artifacts:
         path: artifacts
 
-  build_macos_universal:
-    macos:
-      xcode: '12.2.0'
-
-    steps:
-    - checkout
-
-    - run:
-        name: Setup for builds
-        command: |
-          mkdir -p 'test-results'
-          mkdir -p 'artifacts'
-
-    - run:
-        name: Build for ARM64 macOS
-        command: xcodebuild build -scheme 'LDSwiftEventSource' -arch arm64e -sdk macosx | tee 'artifacts/raw-logs-macosx-arm64e.txt' | xcpretty
-        when: always
-
-    - run:
-        name: Build & Test on x86_64 macOS Simulator
-        command: xcodebuild test -scheme 'LDSwiftEventSource' -sdk macosx -destination 'platform=macOS' | tee 'artifacts/raw-logs-macosx-x86_64.txt' | xcpretty -r junit -o 'test-results/platform-macosx-x86_64/junit.xml'
-        when: always
-
-    - store_test_results:
-        path: test-results
-
-    - store_artifacts:
-        path: artifacts
-
   build_linux:
     parameters:
       docker-image:
@@ -154,9 +136,9 @@ workflows:
   build:
     jobs:
       - build:
-          name: Xcode 13.0 - Swift 5.5
-          xcode-version: '13.0.0'
-          ios-sim: 'platform=iOS Simulator,name=iPhone 11,OS=15.0'
+          name: Xcode 13.1 - Swift 5.5
+          xcode-version: '13.1.0'
+          ios-sim: 'platform=iOS Simulator,name=iPhone 11,OS=15.1'
           build-doc: true
       - build:
           name: Xcode 12.5 - Swift 5.4
@@ -170,10 +152,15 @@ workflows:
           name: Xcode 11.4 - Swift 5.2
           xcode-version: '11.4.1'
           ios-sim: 'platform=iOS Simulator,name=iPhone 8,OS=12.2'
+          build-universal: false
       - build:
           name: Xcode 11.0 - Swift 5.1
           xcode-version: '11.0.0'
           ios-sim: 'platform=iOS Simulator,name=iPhone 8,OS=12.2'
+          build-universal: false
+      - build_linux:
+          name: Linux - Swift 5.5
+          docker-image: norionomura/swift:5.5
       - build_linux:
           name: Linux - Swift 5.4
           docker-image: norionomura/swift:5.4
@@ -189,4 +176,3 @@ workflows:
           name: Linux - Swift 5.1
           docker-image: norionomura/swift:5.1
           discover-tests: true
-      - build_macos_universal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,11 +80,24 @@ jobs:
     - when:
         condition: <<parameters.build-doc>>
         steps:
+          - restore_cache:
+              key: v1-gem-cache-<<parameters.xcode-version>>
+
+          - run:
+              name: Install jazzy gem
+              command: |
+                gem install jazzy
+                gem cleanup
+                # Used as cache key to prevent storing redundant caches
+                gem list > /tmp/cache_key.txt
+
+          - save_cache:
+              key: v1-gem-cache-<<parameters.xcode-version>>-{{ checksum "/tmp/cache-key.txt" }}
+
           - run:
               name: Build Documentation
-              command: |
-                sudo gem install jazzy
-                jazzy -o artifacts/docs
+              command: jazzy -o artifacts/docs
+
           - run:
               name: Validate coverage
               command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,9 +159,6 @@ workflows:
           ios-sim: 'platform=iOS Simulator,name=iPhone 8,OS=12.2'
           build-universal: false
       - build_linux:
-          name: Linux - Swift 5.5
-          docker-image: norionomura/swift:5.5
-      - build_linux:
           name: Linux - Swift 5.4
           docker-image: norionomura/swift:5.4
       - build_linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,8 @@ jobs:
 
           - save_cache:
               key: v1-gem-cache-<<parameters.xcode-version>>-{{ checksum "/tmp/cache-key.txt" }}
+              paths:
+                - ~/.gem
 
           - run:
               name: Build Documentation


### PR DESCRIPTION
Run a build for arm64 in all the Xcode jobs that support running Apple Silicon rather than having a specific job for it.
Cache gem for jazzy when we need to build documentation (saves several minutes on the build after it's cached).