### PR TITLE
Remove deprecated VALID_ARCHS build setting.

### DIFF
--- a/LDSwiftEventSource.xcodeproj/project.pbxproj
+++ b/LDSwiftEventSource.xcodeproj/project.pbxproj
@@ -362,13 +362,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
-				"VALID_ARCHS[sdk=appletvos*]" = "arm64 arm64e";
-				"VALID_ARCHS[sdk=appletvsimulator*]" = x86_64;
-				"VALID_ARCHS[sdk=iphoneos*]" = "arm64 arm64e armv7 armv7s";
-				"VALID_ARCHS[sdk=iphonesimulator*]" = "i386 x86_64";
-				"VALID_ARCHS[sdk=macosx*]" = "x86_64 arm64 arm64e";
-				"VALID_ARCHS[sdk=watchos*]" = "armv7k arm64_32";
-				"VALID_ARCHS[sdk=watchsimulator*]" = "x86_64 i386";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 				WATCHOS_DEPLOYMENT_TARGET = 3.0;
@@ -436,13 +429,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
-				"VALID_ARCHS[sdk=appletvos*]" = "arm64 arm64e";
-				"VALID_ARCHS[sdk=appletvsimulator*]" = x86_64;
-				"VALID_ARCHS[sdk=iphoneos*]" = "arm64 arm64e armv7 armv7s";
-				"VALID_ARCHS[sdk=iphonesimulator*]" = "i386 x86_64";
-				"VALID_ARCHS[sdk=macosx*]" = "x86_64 arm64 arm64e";
-				"VALID_ARCHS[sdk=watchos*]" = "armv7k arm64_32";
-				"VALID_ARCHS[sdk=watchsimulator*]" = "x86_64 i386";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 				WATCHOS_DEPLOYMENT_TARGET = 3.0;


### PR DESCRIPTION
This was a workaround for `xcodebuild` bugs around transient dependencies of libraries with multiple supported SDK and architecture targets. It should no longer be necessary in recent versions of Xcode.