### PR TITLE
Prepare 1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the LaunchDarkly Swift EventSource library will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.3.0] - 2022-01-18
+### Added
+- Added the configuration option `urlSessionConfiguration` to `EventSource.Config` which allows setting the `URLSessionConfiguration` used by the `EventSource` to create `URLSession` instances.
+
+### Fixed
+- Fixed a retain cycle issue when the stream connection is ended.
+- Removed deprecated `VALID_ARCHS` build setting from Xcode project.
+- Unterminated events will no longer be dispatched when the stream connection is dropped.
+- Stream events that set the `lastEventId` will now record the updated `lastEventId` even if the event does not generate a `MessageEvent`.
+- Empty stream "data" fields will now always record a newline to the resultant `MessageEvent` data.
+- Empty stream "event" fields will result in now result in the default "message" event type rather than an event type of "".
+
 ## [1.2.1] - 2021-02-10
 ### Added
 - [SwiftLint](https://github.com/realm/SwiftLint) configuration. Linting will be automatically run as part of the build if [Mint](https://github.com/yonaskolb/Mint) is installed.

--- a/LDSwiftEventSource.podspec
+++ b/LDSwiftEventSource.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "LDSwiftEventSource"
-  s.version      = "1.2.1"
+  s.version      = "1.3.0"
   s.summary      = "Swift EventSource library"
   s.homepage     = "https://github.com/launchdarkly/swift-eventsource"
   s.license      = { :type => "Apache License, Version 2.0", :file => "LICENSE.txt" }

--- a/LDSwiftEventSource.xcodeproj/project.pbxproj
+++ b/LDSwiftEventSource.xcodeproj/project.pbxproj
@@ -458,7 +458,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.3.0;
 				SKIP_INSTALL = YES;
 				"TARGETED_DEVICE_FAMILY[sdk=appletvos*]" = 3;
 				"TARGETED_DEVICE_FAMILY[sdk=appletvsimulator*]" = 3;
@@ -492,7 +492,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.3.0;
 				SKIP_INSTALL = YES;
 				"TARGETED_DEVICE_FAMILY[sdk=appletvos*]" = 3;
 				"TARGETED_DEVICE_FAMILY[sdk=appletvsimulator*]" = 3;

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ LDSwiftEventSource is a cross platform implementation of the [EventSource specif
 To use the [CocoaPods](https://cocoapods.org) dependency manager to integrate LDSwiftEventSource into your Xcode project, specify it in your `Podfile`:
 
 ```ruby
-pod 'LDSwiftEventSource', '~> 1.2'
+pod 'LDSwiftEventSource', '~> 1.3'
 ```
 
 ### Carthage
@@ -27,7 +27,7 @@ pod 'LDSwiftEventSource', '~> 1.2'
 To use the [Carthage](https://github.com/Carthage/Carthage) dependency manager to integrate LDSwiftEventSource into your Xcode project, specify it in your `Cartfile`:
 
 ```ogdl
-github "LaunchDarkly/swift-eventsource" ~> 1.2
+github "LaunchDarkly/swift-eventsource" ~> 1.3
 ```
 
 ### Swift Package Manager
@@ -40,7 +40,7 @@ To include LDSwiftEventSource in a Swift package, simply add it to the dependenc
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/LaunchDarkly/swift-eventsource.git", .upToNextMajor(from: "1.2.0"))
+    .package(url: "https://github.com/LaunchDarkly/swift-eventsource.git", .upToNextMajor(from: "1.3.0"))
 ]
 ```
 


### PR DESCRIPTION
## [1.3.0] - 2022-01-18
### Added
- Added the configuration option `urlSessionConfiguration` to `EventSource.Config` which allows setting the `URLSessionConfiguration` used by the `EventSource` to create `URLSession` instances.

### Fixed
- Fixed a retain cycle issue when the stream connection is ended.
- Removed deprecated `VALID_ARCHS` build setting from Xcode project.
- Unterminated events will no longer be dispatched when the stream connection is dropped.
- Stream events that set the `lastEventId` will now record the updated `lastEventId` even if the event does not generate a `MessageEvent`.
- Empty stream "data" fields will now always record a newline to the resultant `MessageEvent` data.
- Empty stream "event" fields will result in now result in the default "message" event type rather than an event type of "".
