### PR TITLE
[sc-145480] Fix race condition on stop during reconnection. 

### DIFF
--- a/LDSwiftEventSource.xcodeproj/project.pbxproj
+++ b/LDSwiftEventSource.xcodeproj/project.pbxproj
@@ -253,7 +253,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo `pwd`\nif which mint >/dev/null; then\n  /usr/bin/xcrun --sdk macosx mint run realm/SwiftLint\nelse\n  echo \"warning: mint not installed, available from https://github.com/yonaskolb/Mint\"\nfi\n";
+			shellScript = "# Adds support for Apple Silicon brew directory\nexport PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which mint >/dev/null; then\n  /usr/bin/xcrun --sdk macosx mint run realm/SwiftLint\nelse\n  echo \"warning: mint not installed, available from https://github.com/yonaskolb/Mint\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */


### PR DESCRIPTION
Broke out reconnection timing logic. Simplified the reconnection logic and moved responsibility over certain fields from `EventSourceDelegate` to `EventParser` to simplify concurrency concerns. Updated build script for
linting with SwiftLint using mint to add PATH for brew installed mint on Apple Silicon.