### PR TITLE
Prepare 1.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the LaunchDarkly Swift EventSource library will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.3.1] - 2022-03-11
+### Fixed
+- Fixed a race condition that could cause a crash when `stop()` is called when there is a pending reconnection attempt.
+
 ## [1.3.0] - 2022-01-18
 ### Added
 - Added the configuration option `urlSessionConfiguration` to `EventSource.Config` which allows setting the `URLSessionConfiguration` used by the `EventSource` to create `URLSession` instances.

--- a/LDSwiftEventSource.podspec
+++ b/LDSwiftEventSource.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "LDSwiftEventSource"
-  s.version      = "1.3.0"
+  s.version      = "1.3.1"
   s.summary      = "Swift EventSource library"
   s.homepage     = "https://github.com/launchdarkly/swift-eventsource"
   s.license      = { :type => "Apache License, Version 2.0", :file => "LICENSE.txt" }

--- a/LDSwiftEventSource.xcodeproj/project.pbxproj
+++ b/LDSwiftEventSource.xcodeproj/project.pbxproj
@@ -458,7 +458,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				SKIP_INSTALL = YES;
 				"TARGETED_DEVICE_FAMILY[sdk=appletvos*]" = 3;
 				"TARGETED_DEVICE_FAMILY[sdk=appletvsimulator*]" = 3;
@@ -492,7 +492,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				SKIP_INSTALL = YES;
 				"TARGETED_DEVICE_FAMILY[sdk=appletvos*]" = 3;
 				"TARGETED_DEVICE_FAMILY[sdk=appletvsimulator*]" = 3;

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To include LDSwiftEventSource in a Swift package, simply add it to the dependenc
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/LaunchDarkly/swift-eventsource.git", .upToNextMajor(from: "1.3.0"))
+    .package(url: "https://github.com/LaunchDarkly/swift-eventsource.git", .upToNextMajor(from: "1.3.1"))
 ]
 ```
 


### PR DESCRIPTION
## [1.3.1] - 2022-03-11
### Fixed
- Fixed a race condition that could cause a crash when `stop()` is called when there is a pending reconnection attempt.