### PR TITLE
Update xcode image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,10 +161,6 @@ workflows:
           xcode-version: '12.5.1'
           ios-sim: 'platform=iOS Simulator,name=iPhone 8,OS=14.5'
       - build:
-          name: Xcode 12.0 - Swift 5.3
-          xcode-version: '12.0.1'
-          ios-sim: 'platform=iOS Simulator,name=iPhone 8,OS=14.0'
-      - build:
           name: Xcode 11.7 - Swift 5.2
           xcode-version: '11.7.0'
           ios-sim: 'platform=iOS Simulator,name=iPhone 8,OS=12.4'


### PR DESCRIPTION
According to the CircleCI announcement on [June 2nd, 2022][1], several
xcode images are going to be deprecated and removed. This commit bumps
our xcode versions to a supported image version.

[1]: https://discuss.circleci.com/t/xcode-image-deprecation/44294