### PR TITLE
Remove explicitly typed package products

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,14 +11,7 @@ let package = Package(
         .tvOS(.v10)
     ],
     products: [
-        .library(
-            name: "LDSwiftEventSource",
-            type: .dynamic,
-            targets: ["LDSwiftEventSource"]),
-        .library(
-            name: "LDSwiftEventSourceStatic",
-            type: .static,
-            targets: ["LDSwiftEventSource"]),
+        .library(name: "LDSwiftEventSource", targets: ["LDSwiftEventSource"]),
     ],
     dependencies: [],
     targets: [


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
   - No tests to add AFAICT
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions
   - Not sure what I can do to test all supported platform versions, hoping that CI/project members can help out here

**Related issues**

Didn't create an issue up-front as it seemed like more work than just contributing a PR :)

**Describe the solution you've provided**

As of Xcode 14 beta 5 (have not tested earlier betas, it works on 13.4.1), adding the LaunchDarkly SDK to a project breaks SwiftUI previews. The error you get is _fairly_ non-descriptive but strongly hints to an issue finding an executable (?) for the `LDSwiftEventSourceStatic` product:

> SettingsError: noExecutablePath(<IDESwiftPackageStaticLibraryProductBuildable:ObjectIdentifier(0x0000600046ac78d0):'LDSwiftEventSourceStatic'>)

Looking at the Package.swift file for LaunchDarkly I noticed that it's referencing the explicitly static typed target for the event source package. Changing this to a target without explicit package type solves the issue. This is trivially reproducible using Xcode 14b5:
 - Create a new app project using SwiftUI
 - Add LaunchDarkly via SPM
 - Try to run SwiftUI Previews

I'm not sure why this package declares both types explicitly, as [this isn't the recommended approach when a package supports both static and dynamic linking as noted by SPM documentation](https://github.com/apple/swift-package-manager/blob/main/Documentation/PackageDescription.md#methods-2) (note the `type` parameter docs). I'm sure there's a reason though, so in order to limit breaking changes this PR renames the current `LDSwiftEventSource` product to `LDSwiftEventSourceDynamic` and introduces a new `LDSwiftEventSource` without an explicit product type. Doing this and changing the LaunchDarkly package to reference this new target instead of the static one, the project created above renders previews successfully. The downside is that any library consumers relying on the fact that `LDSwiftEventSource` is of dynamic type now might see build/linkage failures. 

**Describe alternatives you've considered**

None, as I'm not sure what other solutions might exist.

**Additional context**

None.
