### PR TITLE
Fix start() re-entrancy (#1)

### DIFF
--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -168,6 +168,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
                 self.logger.log(.info, "start() called on already-started EventSource object. Returning")
                 return
             }
+            self.readyState = .connecting
             self.urlSession = self.createSession()
             self.connect()
         }

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -207,6 +207,17 @@ final class LDSwiftEventSourceTests: XCTestCase {
         XCTAssertEqual(handler.request.allHTTPHeaderFields?["X-LD-Header"], "def")
         es.stop()
     }
+    
+    func testStartRequestIsNotReentrant() {
+        var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
+        config.urlSessionConfiguration = sessionWithMockProtocol()
+        let es = EventSource(config: config)
+        es.start()
+        es.start()
+        _ = MockingProtocol.requested.expectEvent()
+        MockingProtocol.requested.expectNoEvent()
+        es.stop()
+    }
 
     func testSuccessfulResponseOpens() {
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)


### PR DESCRIPTION
Fixes an `EventSource.start()` re-entrancy problem

When:
1. `EventSource.start()` is called
2. `EventSource.start()` is called again, before the network response from the first call has been received

Then:
- a second `URLSession` and `URLRequest` are created, and a new `URLSessionDataTask` is started

The underlying issue is that `start()` is checking for `readyState` == `.raw`, but `readyState` isn't set until a network response has been received.

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

None

**Describe the solution you've provided**

Set `readyState = .connecting` in `start()`, immediately after checking for `readyState == .raw`.

**Describe alternatives you've considered**

None

**Additional context**

None
