### PR TITLE
feat: Specify TLS v1.2 as required minimum

### DIFF
--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -86,11 +86,13 @@ public class EventSource {
                 sessionConfig.httpAdditionalHeaders = ["Accept": "text/event-stream", "Cache-Control": "no-cache"]
                 sessionConfig.timeoutIntervalForRequest = idleTimeout
 
+                #if !os(Linux)
                 if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
                     sessionConfig.tlsMinimumSupportedProtocolVersion = .TLSv12
                 } else {
                     sessionConfig.tlsMinimumSupportedProtocol = .tlsProtocol12
                 }
+                #endif
                 return sessionConfig
             }
             set {

--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -85,6 +85,12 @@ public class EventSource {
                 let sessionConfig = _urlSessionConfiguration.copy() as! URLSessionConfiguration
                 sessionConfig.httpAdditionalHeaders = ["Accept": "text/event-stream", "Cache-Control": "no-cache"]
                 sessionConfig.timeoutIntervalForRequest = idleTimeout
+
+                if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
+                    sessionConfig.tlsMinimumSupportedProtocolVersion = .TLSv12
+                } else {
+                    sessionConfig.tlsMinimumSupportedProtocol = .tlsProtocol12
+                }
                 return sessionConfig
             }
             set {


### PR DESCRIPTION
TLS 1.1 has been deprecated for a long time and has been dropped by most major providers. The LaunchDarkly APIs haven't accepted anything lower than TLS 1.2 for a long time.

We are therefore forcing TLS 1.2 as the minimum going forward in this library.