### PR TITLE
prepare 3.1.0 release (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the LaunchDarkly Swift EventSource library will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [3.1.0] - 2023-06-05
+### Changed:
+- Enforce TLS v1.2 as a required minimum.
+
+### Fixed:
+- Fix re-entrancy issue with `start` command. (Thanks, [g-mark](https://github.com/launchdarkly/swift-eventsource/pull/56)!)
+
 ## [3.0.0] - 2022-10-06
 ### Changed
 - Dropped support for older versions in accordance with the new [Xcode 14 release](https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes).

--- a/LDSwiftEventSource.podspec
+++ b/LDSwiftEventSource.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "LDSwiftEventSource"
-  s.version      = "3.0.0"
+  s.version      = "3.1.0"
   s.summary      = "Swift EventSource library"
   s.homepage     = "https://github.com/launchdarkly/swift-eventsource"
   s.license      = { :type => "Apache License, Version 2.0", :file => "LICENSE.txt" }

--- a/LDSwiftEventSource.xcodeproj/project.pbxproj
+++ b/LDSwiftEventSource.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.1.0;
 				SKIP_INSTALL = YES;
 				"TARGETED_DEVICE_FAMILY[sdk=appletvos*]" = 3;
 				"TARGETED_DEVICE_FAMILY[sdk=appletvsimulator*]" = 3;
@@ -495,7 +495,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 3.1.0;
 				SKIP_INSTALL = YES;
 				"TARGETED_DEVICE_FAMILY[sdk=appletvos*]" = 3;
 				"TARGETED_DEVICE_FAMILY[sdk=appletvsimulator*]" = 3;

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ LDSwiftEventSource is a cross platform implementation of the [EventSource specif
 To use the [CocoaPods](https://cocoapods.org) dependency manager to integrate LDSwiftEventSource into your Xcode project, specify it in your `Podfile`:
 
 ```ruby
-pod 'LDSwiftEventSource', '~> 3.0'
+pod 'LDSwiftEventSource', '~> 3.1'
 ```
 
 ### Carthage
@@ -27,7 +27,7 @@ pod 'LDSwiftEventSource', '~> 3.0'
 To use the [Carthage](https://github.com/Carthage/Carthage) dependency manager to integrate LDSwiftEventSource into your Xcode project, specify it in your `Cartfile`:
 
 ```ogdl
-github "LaunchDarkly/swift-eventsource" ~> 3.0
+github "LaunchDarkly/swift-eventsource" ~> 3.1
 ```
 
 ### Swift Package Manager
@@ -40,7 +40,7 @@ To include LDSwiftEventSource in a Swift package, simply add it to the dependenc
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/LaunchDarkly/swift-eventsource.git", .upToNextMajor(from: "3.0.0"))
+    .package(url: "https://github.com/LaunchDarkly/swift-eventsource.git", .upToNextMajor(from: "3.1.0"))
 ]
 ```
 


### PR DESCRIPTION
## [3.1.0] - 2023-06-05
### Changed:
- Enforce TLS v1.2 as a required minimum.

### Fixed:
- Fix re-entrancy issue with `start` command. (Thanks, [g-mark](https://github.com/launchdarkly/swift-eventsource/pull/56)!)