### PR TITLE
feat: add dataTaskCompletionHandler to EventSource config

### DIFF
--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -117,6 +117,11 @@ public class EventSource {
             }
             return .proceed
         }
+        
+        
+        public var dataTaskCompletionHandler: (Data?, URLResponse?, Error?) -> Void = { (data, response, error) in
+            //
+        }
 
         /// Create a new configuration with an `EventHandler` and a `URL`
         public init(handler: EventHandler, url: URL) {
@@ -230,7 +235,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
 
     private func connect() {
         logger.log(.info, "Starting EventSource client")
-        let task = urlSession?.dataTask(with: createRequest())
+        let task = urlSession?.dataTask(with: createRequest(), completionHandler: self.config.dataTaskCompletionHandler)
         task?.resume()
         sessionTask = task
     }


### PR DESCRIPTION
Hi Thanks for great library. 
It works well with my project! 

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

I needed to read response data (json error message from server) when request error occurred while creating connection. 
But only `responseCode` is available for UnsuccessfulResponseError. 
So I added config to use `completionHandler` on creating urlSession dataTask. 

**Describe the solution you've provided**

Added `dataTaskCompletionHandler` option. 

**Describe alternatives you've considered**

I don't have any other idea to achieve this. 

**Additional context**

