### PR TITLE
feat: Raise to Swift 6 tooling and add Sendable conformances to public types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: Run CI
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "4.x" ]
     paths-ignore:
       - '**.md' # Do not need to run CI for markdown changes.
   pull_request:
-    branches: [ main ]
+    branches: [ main, "4.x" ]
     paths-ignore:
       - '**.md'
 
@@ -117,9 +117,8 @@ jobs:
       fail-fast: false
       matrix:
         swift-version:
-          - 5.7
-          - 5.8
-          - 5.9
+          - "6.0"
+          - "6.1"
 
     container: swift:${{ matrix.swift-version }}
 
@@ -127,7 +126,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build and test
-        run: swift test --enable-test-discovery
+        run: swift test
 
   windows-build:
     name: Windows - Swift 6.1

--- a/ContractTestService/Package.swift
+++ b/ContractTestService/Package.swift
@@ -1,14 +1,14 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.9
 
 import PackageDescription
 
 let package = Package(
   name: "ContractTestService",
   platforms: [
-    .iOS(.v11),
-    .macOS(.v10_13),
-    .watchOS(.v4),
-    .tvOS(.v11),
+    .iOS(.v16),
+    .macOS(.v13),
+    .watchOS(.v9),
+    .tvOS(.v16),
   ],
   products: [
     .executable(
@@ -18,14 +18,14 @@ let package = Package(
   ],
   dependencies: [
     // Local dependency to LDSwiftEventSource
-    .package(path: ".."),
+    .package(name: "LDSwiftEventSource", path: ".."),
     .package(url: "https://github.com/Kitura/Kitura", from: "2.9.200")
   ],
   targets: [
     .target(
       name: "ContractTestService",
       dependencies: [
-        "LDSwiftEventSource",
+        .product(name: "LDSwiftEventSource", package: "LDSwiftEventSource"),
         "Kitura"
       ]
     )

--- a/Package.swift
+++ b/Package.swift
@@ -1,14 +1,14 @@
-// swift-tools-version:5.0
+// swift-tools-version:6.0
 
 import PackageDescription
 
 let package = Package(
     name: "LDSwiftEventSource",
     platforms: [
-        .iOS(.v11),
-        .macOS(.v10_13),
-        .watchOS(.v4),
-        .tvOS(.v11)
+        .iOS(.v16),
+        .macOS(.v13),
+        .tvOS(.v16),
+        .watchOS(.v9),
     ],
     products: [
         .library(name: "LDSwiftEventSource", targets: ["LDSwiftEventSource"]),
@@ -17,10 +17,22 @@ let package = Package(
     targets: [
         .target(
             name: "LDSwiftEventSource",
-            path: "Source"),
+            path: "Source",
+            swiftSettings: [
+                // Sendable annotations land first under v5 (mismatches are warnings);
+                // the .v6 flip comes with the delegate/logging Sendable cleanup.
+                .swiftLanguageMode(.v5),
+            ]
+        ),
         .testTarget(
             name: "LDSwiftEventSourceTests",
             dependencies: ["LDSwiftEventSource"],
-            path: "Tests"),
-    ],
-    swiftLanguageVersions: [.v5])
+            path: "Tests",
+            swiftSettings: [
+                // Sendable annotations land first under v5 (mismatches are warnings);
+                // the .v6 flip comes with the delegate/logging Sendable cleanup.
+                .swiftLanguageMode(.v5),
+            ]
+        ),
+    ]
+)

--- a/Source/EventParser.swift
+++ b/Source/EventParser.swift
@@ -65,7 +65,7 @@ class EventParser {
         case Constants.eventLabel:
             eventType = String(value)
         case Constants.retryLabel:
-            if value.allSatisfy(("0"..."9").contains), let reconnectionTime = Int64(value) {
+            if value.allSatisfy({ ("0"..."9").contains($0) }), let reconnectionTime = Int64(value) {
                 currentRetry = Double(reconnectionTime) * 0.001
             }
         default:

--- a/Source/Types.swift
+++ b/Source/Types.swift
@@ -6,16 +6,16 @@ import Foundation
  This is different from `EventHandler.onError(error:)` in that it will not be called for other kinds of errors; also,
  it has the ability to tell the client to stop reconnecting by returning a `ConnectionErrorAction.shutdown`.
 */
-public typealias ConnectionErrorHandler = (Error) -> ConnectionErrorAction
+public typealias ConnectionErrorHandler = @Sendable (Error) -> ConnectionErrorAction
 
 /**
  Type for a function that will take in the current HTTP headers and return a new set of HTTP headers to be used when
  connecting and reconnecting to a stream.
  */
-public typealias HeaderTransform = ([String: String]) -> [String: String]
+public typealias HeaderTransform = @Sendable ([String: String]) -> [String: String]
 
 /// Potential actions a `ConnectionErrorHandler` can return
-public enum ConnectionErrorAction {
+public enum ConnectionErrorAction: Sendable {
     /**
      Specifies that the error should be logged normally and dispatched to the `EventHandler`. Connection retrying will
      proceed normally if appropriate.
@@ -29,7 +29,7 @@ public enum ConnectionErrorAction {
 }
 
 /// Struct representing received event from the stream.
-public struct MessageEvent: Equatable, Hashable {
+public struct MessageEvent: Equatable, Hashable, Sendable {
     /// The event data of the event.
     public let data: String
     /// The last seen event id, or the event id set in the Config if none have been received.
@@ -48,7 +48,7 @@ public struct MessageEvent: Equatable, Hashable {
 }
 
 /// Protocol for an object that will receive SSE events.
-public protocol EventHandler {
+public protocol EventHandler: Sendable {
     /// EventSource calls this method when the stream connection has been opened.
     func onOpened()
 
@@ -82,7 +82,7 @@ public protocol EventHandler {
 }
 
 /// Enum values representing the states of an EventSource
-public enum ReadyState: String, Equatable {
+public enum ReadyState: String, Equatable, Sendable {
     /// The `EventSource` client has not been started yet.
     case raw
     /// The `EventSource` client is attempting to make a connection.
@@ -96,7 +96,7 @@ public enum ReadyState: String, Equatable {
 }
 
 /// Error class that indicates the remote server returned an unsuccessful HTTP response code.
-public class UnsuccessfulResponseError: Error {
+public final class UnsuccessfulResponseError: Error, Sendable {
     /// The HTTP response code received.
     public let responseCode: Int
 


### PR DESCRIPTION
First step of the Swift 6 modernization. Moves the package to
swift-tools-version 6.0, raises the platform floor to match swift-core
(iOS 16 / macOS 13 / tvOS 16 / watchOS 9), and marks the public API
types Sendable ahead of the language-mode switch.

- Package.swift: tools 6.0, raised platforms.
- Types.swift: Sendable on MessageEvent, ConnectionErrorAction, ReadyState,
  UnsuccessfulResponseError (now final), EventHandler, and the
  ConnectionErrorHandler / HeaderTransform closure typealiases.
- EventParser.swift: fix the retry-field digit check for Swift 6 type
  inference (behavior preserving, ASCII 0-9 only).

The target stays on the Swift 5 language mode for now, where the new
Sendable conformances surface as warnings rather than errors, so the
package still builds and all tests pass. The .swiftLanguageMode(.v6)
switch lands with the delegate and logging cleanup that makes the
internals conform.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raised deployment targets and Sendable/`EventHandler` requirements can break consumers on older OS versions or non-Sendable handlers; behavior stays on Swift 5 mode until a follow-up flips to v6.
> 
> **Overview**
> This PR is the first Swift 6 modernization step: **package tooling moves to Swift 6.0**, **minimum OS versions align with swift-core** (iOS 16, macOS 13, tvOS 16, watchOS 9), and **public types are annotated for concurrency** while compilation still uses **Swift 5 language mode** via per-target `.swiftLanguageMode(.v5)`.
> 
> **CI** now runs on `main` and `4.x`, Linux tests **Swift 6.0 and 6.1** (replacing 5.7–5.9), and `swift test` no longer passes `--enable-test-discovery`. **ContractTestService** bumps tools to 5.9, matches the new platform floor, and uses an explicit local package product dependency.
> 
> **Public API** adds `Sendable` (and `@Sendable` on `ConnectionErrorHandler` / `HeaderTransform`); `UnsuccessfulResponseError` is **`final`**. **EventParser** fixes the retry-field digit check with an explicit closure for Swift 6 type inference (same ASCII 0–9 behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f744921c3ac90069c506e3f6ef117d6ef63e9498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->