### PR TITLE
chore: Move the whole package to the Swift 6 language mode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,20 +22,13 @@ let package = Package(
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
             ],
-            path: "Source",
-            swiftSettings: [
-                .swiftLanguageMode(.v6),
-            ]
+            path: "Source"
         ),
         .testTarget(
             name: "LDSwiftEventSourceTests",
             dependencies: ["LDSwiftEventSource"],
-            path: "Tests",
-            swiftSettings: [
-                // Library is on the v6 language mode; the test target follows in a
-                // later step once the test doubles are made Sendable.
-                .swiftLanguageMode(.v5),
-            ]
+            path: "Tests"
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v6]
 )

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -142,25 +142,25 @@ final class LDSwiftEventSourceTests: XCTestCase {
     }
 
     func testDispatchError() {
-        var connectionErrorHandlerCallCount = 0
-        var connectionErrorAction: ConnectionErrorAction = .proceed
+        let connectionErrorHandlerCallCount = Box(0)
+        let connectionErrorAction = Box<ConnectionErrorAction>(.proceed)
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "abc")!)
         config.connectionErrorHandler = { _ in
-            connectionErrorHandlerCallCount += 1
-            return connectionErrorAction
+            connectionErrorHandlerCallCount.value += 1
+            return connectionErrorAction.value
         }
         let es = EventSourceDelegate(config: config)
         XCTAssertEqual(es.dispatchError(error: DummyError()), .proceed)
-        XCTAssertEqual(connectionErrorHandlerCallCount, 1)
+        XCTAssertEqual(connectionErrorHandlerCallCount.value, 1)
         guard case .error(let err) = mockHandler.events.expectEvent(), err is DummyError
         else {
             XCTFail("handler should receive error if EventSource is not shutting down")
             return
         }
         mockHandler.events.expectNoEvent()
-        connectionErrorAction = .shutdown
+        connectionErrorAction.value = .shutdown
         XCTAssertEqual(es.dispatchError(error: DummyError()), .shutdown)
-        XCTAssertEqual(connectionErrorHandlerCallCount, 2)
+        XCTAssertEqual(connectionErrorHandlerCallCount.value, 2)
     }
 
     func sessionWithMockProtocol() -> URLSessionConfiguration {
@@ -393,4 +393,4 @@ final class LDSwiftEventSourceTests: XCTestCase {
 #endif
 }
 
-private class DummyError: Error { }
+private struct DummyError: Error { }

--- a/Tests/MockHandler.swift
+++ b/Tests/MockHandler.swift
@@ -21,8 +21,8 @@ enum ReceivedEvent: Equatable {
     }
 }
 
-class MockHandler: EventHandler {
-    var events = EventSink<ReceivedEvent>()
+final class MockHandler: EventHandler {
+    let events = EventSink<ReceivedEvent>()
 
     func onOpened() { events.record(.opened) }
     func onClosed() { events.record(.closed) }

--- a/Tests/TestUtil.swift
+++ b/Tests/TestUtil.swift
@@ -4,44 +4,84 @@ import XCTest
 import FoundationNetworking
 #endif
 
-struct EventSink<T> {
-    private let semaphore = DispatchSemaphore(value: 0)
-    private let queue = DispatchQueue(label: "EventSinkQueue." + UUID().uuidString)
+// A thread-safe queue used to hand events from the background threads that drive
+// the mocks (the URLSession delegate queue, the URLProtocol loading thread) to the
+// test thread, which blocks waiting for them. A reference type guarded by an
+// `NSCondition` so it can be shared across those threads; `@unchecked Sendable`
+// because the locking the compiler cannot verify is what makes the access safe.
+final class EventSink<T>: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var receivedEvents: [T] = []
 
-    var receivedEvents: [T] = []
-
-    mutating func record(_ event: T) {
-        queue.sync { receivedEvents.append(event) }
-        semaphore.signal()
+    func record(_ event: T) {
+        condition.lock()
+        defer { condition.unlock() }
+        receivedEvents.append(event)
+        condition.signal()
     }
 
-    mutating func expectEvent(maxWait: TimeInterval = 1.0) -> T {
-        switch semaphore.wait(timeout: DispatchTime.now() + maxWait) {
-        case .success:
-            return queue.sync { receivedEvents.remove(at: 0) }
-        case .timedOut:
-            XCTFail("Expected mock handler to be called")
-            return (nil as T?)!
+    func expectEvent(maxWait: TimeInterval = 1.0) -> T {
+        let deadline = Date(timeIntervalSinceNow: maxWait)
+        condition.lock()
+        defer { condition.unlock() }
+        while receivedEvents.isEmpty {
+            guard condition.wait(until: deadline)
+            else {
+                XCTFail("Expected mock handler to be called")
+                return (nil as T?)!
+            }
         }
+        return receivedEvents.removeFirst()
     }
 
-    mutating func maybeEvent() -> T? {
-        switch semaphore.wait(timeout: DispatchTime.now()) {
-        case .success:
-            return queue.sync { receivedEvents.remove(at: 0) }
-        case .timedOut:
-            return nil
-        }
+    func maybeEvent() -> T? {
+        condition.lock()
+        defer { condition.unlock() }
+        return receivedEvents.isEmpty ? nil : receivedEvents.removeFirst()
     }
 
     func expectNoEvent(within: TimeInterval = 0.1) {
-        if case .success = semaphore.wait(timeout: DispatchTime.now() + within) {
-            XCTFail("Expected no events in sink, found \(String(describing: receivedEvents.first))")
+        let deadline = Date(timeIntervalSinceNow: within)
+        condition.lock()
+        defer { condition.unlock() }
+        while receivedEvents.isEmpty {
+            guard condition.wait(until: deadline)
+            else { return }
+        }
+        XCTFail("Expected no events in sink, found \(String(describing: receivedEvents.first))")
+    }
+
+    func reset() {
+        condition.lock()
+        defer { condition.unlock() }
+        receivedEvents.removeAll()
+    }
+}
+
+// A lock-protected reference cell so tests can read and mutate a value from inside
+// the `@Sendable` configuration closures (e.g. connectionErrorHandler) without
+// tripping the concurrent-capture checks of the v6 language mode.
+final class Box<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: T
+
+    init(_ value: T) { storedValue = value }
+
+    var value: T {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return storedValue
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            storedValue = newValue
         }
     }
 }
 
-class RequestHandler {
+final class RequestHandler {
     let proto: URLProtocol
     let request: URLRequest
     let client: URLProtocolClient?
@@ -86,10 +126,10 @@ class MockingProtocol: URLProtocol {
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canInit(with task: URLSessionTask) -> Bool { true }
 
-    static var requested = EventSink<RequestHandler>()
+    static let requested = EventSink<RequestHandler>()
 
     class func resetRequested() {
-        requested = EventSink<RequestHandler>()
+        requested.reset()
     }
 
     private var currentlyLoading: RequestHandler?


### PR DESCRIPTION
Completes the Swift 6 migration started in SDK-2593: the library target was
already on the v6 language mode while the test target stayed on v5 as a
temporary seam until the test doubles were made Sendable. This makes the whole
package build and test under the v6 language mode.

- Rework EventSink<T> from a mutating value type backed by a semaphore + serial
  queue into a final, @unchecked Sendable class guarded by an NSCondition, with
  a reset() so the shared instance can be reused across tests.
- Make MockHandler and RequestHandler final, and EventSink properties immutable.
- Replace MockingProtocol's static mutable `requested` with a static let that is
  reset() between tests rather than reassigned.
- Add a lock-protected Box<T> so tests can mutate counters/actions captured by
  the @Sendable connectionErrorHandler closures.
- Turn DummyError into a struct so it is trivially Sendable.
- Declare the v6 language mode once at the package level via
  swiftLanguageModes: [.v6] instead of per target.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to Package.swift and test support code; production library sources are unchanged aside from shared language mode.
> 
> **Overview**
> Finishes the Swift 6 migration by applying **`swiftLanguageModes: [.v6]`** at the package level instead of per-target settings, so tests compile under the same rules as the library.
> 
> Test infrastructure is reworked for v6 concurrency: **`EventSink`** becomes a lock-guarded `@unchecked Sendable` class (replacing a mutating struct with semaphore/queue), with **`reset()`** so **`MockingProtocol.requested`** can stay a **`static let`**. **`MockHandler`** is **`final`** with an immutable events sink; **`Box<T>`** lets **`testDispatchError`** mutate counters inside **`@Sendable`** **`connectionErrorHandler`** closures; **`DummyError`** becomes a struct for trivial Sendability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49eec470518f64bc54aba38d8e4a86423e907136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->