### PR TITLE
test: Migrate the test suite from XCTest to swift-testing

### DIFF
--- a/.github/actions/test-swiftpm/action.yml
+++ b/.github/actions/test-swiftpm/action.yml
@@ -6,4 +6,4 @@ runs:
   steps:
     - name: Build & Test with SwiftPM
       shell: bash
-      run: swift test -v 2>&1 | xcpretty
+      run: swift test

--- a/Tests/EventParserTests.swift
+++ b/Tests/EventParserTests.swift
@@ -1,61 +1,60 @@
-import XCTest
+import Foundation
+import Testing
 @testable import LDSwiftEventSource
 
-final class EventParserTests: XCTestCase {
-    var handler: MockHandler!
-    var parser: EventParser!
+@Suite("EventParser")
+final class EventParserTests {
+    private let handler = MockHandler()
+    private let parser: EventParser
 
-    override func setUp() {
-        super.setUp()
-        handler = MockHandler()
+    init() {
         parser = EventParser(handler: handler, initialEventId: "", initialRetry: 1.0)
     }
 
-    override func tearDown() {
-        super.tearDown()
-        XCTAssertNil(handler.events.maybeEvent())
+    deinit {
+        #expect(handler.events.maybeEvent() == nil)
     }
 
     // MARK: Retry time tests
-    func testUnsetRetryReturnsConfigured() {
-        parser = EventParser(handler: handler, initialEventId: "", initialRetry: 5.0)
-        XCTAssertEqual(parser.reset(), 5.0)
+    @Test func unsetRetryReturnsConfigured() {
+        let parser = EventParser(handler: handler, initialEventId: "", initialRetry: 5.0)
+        #expect(parser.reset() == 5.0)
     }
 
-    func testSetsRetryTimeToSevenSeconds() {
+    @Test func setsRetryTimeToSevenSeconds() {
         parser.parse(line: "retry: 7000")
-        XCTAssertEqual(parser.reset(), 7.0)
-        XCTAssertEqual(parser.getLastEventId(), "")
+        #expect(parser.reset() == 7.0)
+        #expect(parser.getLastEventId() == "")
     }
 
-    func testRetryWithNoSpace() {
+    @Test func retryWithNoSpace() {
         parser.parse(line: "retry:7000")
-        XCTAssertEqual(parser.reset(), 7.0)
-        XCTAssertEqual(parser.getLastEventId(), "")
+        #expect(parser.reset() == 7.0)
+        #expect(parser.getLastEventId() == "")
     }
 
-    func testDoesNotSetRetryTimeUnlessEntireValueIsNumeric() {
+    @Test func doesNotSetRetryTimeUnlessEntireValueIsNumeric() {
         parser.parse(line: "retry: 7000L")
-        XCTAssertEqual(parser.reset(), 1.0)
+        #expect(parser.reset() == 1.0)
     }
 
-    func testSafeToUseEmptyRetryTime() {
+    @Test func safeToUseEmptyRetryTime() {
         parser.parse(line: "retry")
-        XCTAssertEqual(parser.reset(), 1.0)
+        #expect(parser.reset() == 1.0)
     }
 
-    func testSafeToAttemptToSetRetryToOutOfBoundsValue() {
+    @Test func safeToAttemptToSetRetryToOutOfBoundsValue() {
         parser.parse(line: "retry: 10000000000000000000000000")
-        XCTAssertEqual(parser.reset(), 1.0)
+        #expect(parser.reset() == 1.0)
     }
 
-    func testResetDoesNotResetRetry() {
+    @Test func resetDoesNotResetRetry() {
         parser.parse(line: "retry: 7000")
-        XCTAssertEqual(parser.reset(), 7.0)
-        XCTAssertEqual(parser.reset(), 7.0)
+        #expect(parser.reset() == 7.0)
+        #expect(parser.reset() == 7.0)
     }
 
-    func testRetryNotChangedDuringOtherMessages() {
+    @Test func retryNotChangedDuringOtherMessages() {
         parser.parse(line: "retry: 7000")
         parser.parse(line: "")
         parser.parse(line: ":123")
@@ -64,247 +63,247 @@ final class EventParserTests: XCTestCase {
         parser.parse(line: "id: 123")
         parser.parse(line: "none: 123")
         parser.parse(line: "")
-        XCTAssertEqual(parser.reset(), 7.0)
+        #expect(parser.reset() == 7.0)
         _ = handler.events.maybeEvent()
         _ = handler.events.maybeEvent()
     }
 
     // MARK: Comment tests
-    func testEmptyComment() {
+    @Test func emptyComment() {
         parser.parse(line: ":")
-        XCTAssertEqual(handler.events.maybeEvent(), .comment(""))
+        #expect(handler.events.maybeEvent() == .comment(""))
     }
 
-    func testCommentBody() {
+    @Test func commentBody() {
         parser.parse(line: ": comment")
-        XCTAssertEqual(handler.events.maybeEvent(), .comment(" comment"))
+        #expect(handler.events.maybeEvent() == .comment(" comment"))
     }
 
-    func testCommentCanContainColon() {
+    @Test func commentCanContainColon() {
         parser.parse(line: ":comment:line")
-        XCTAssertEqual(handler.events.maybeEvent(), .comment("comment:line"))
+        #expect(handler.events.maybeEvent() == .comment("comment:line"))
     }
 
     // MARK: Message data tests
-    func testDispatchesEmptyMessageData() {
+    @Test func dispatchesEmptyMessageData() {
         parser.parse(line: "data")
         parser.parse(line: "")
         parser.parse(line: "data:")
         parser.parse(line: "")
         parser.parse(line: "data: ")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "", lastEventId: "")))
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "", lastEventId: "")))
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "", lastEventId: "")))
     }
 
-    func testDoesNotRemoveTrailingSpaceWhenColonNotPresent() {
+    @Test func doesNotRemoveTrailingSpaceWhenColonNotPresent() {
         parser.parse(line: "data ")
         parser.parse(line: "")
-        XCTAssertNil(handler.events.maybeEvent())
+        #expect(handler.events.maybeEvent() == nil)
     }
 
-    func testEmptyFirstDataAppendsNewline() {
+    @Test func emptyFirstDataAppendsNewline() {
         parser.parse(line: "data:")
         parser.parse(line: "data:")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "\n", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "\n", lastEventId: "")))
     }
 
-    func testDispatchesSingleLineMessage() {
+    @Test func dispatchesSingleLineMessage() {
         parser.parse(line: "data: hello")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "hello", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "hello", lastEventId: "")))
     }
 
-    func testEmptyDataWithBufferedDataAppendsNewline() {
+    @Test func emptyDataWithBufferedDataAppendsNewline() {
         parser.parse(line: "data: data1")
         parser.parse(line: "data: ")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "data1\n", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "data1\n", lastEventId: "")))
     }
 
-    func testDataResetAfterEvent() {
+    @Test func dataResetAfterEvent() {
         parser.parse(line: "data: hello")
         parser.parse(line: "")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "hello", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "hello", lastEventId: "")))
     }
 
-    func testRemovesOnlyFirstSpace() {
+    @Test func removesOnlyFirstSpace() {
         parser.parse(line: "data:  {\"foo\": \"bar baz\"}")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: " {\"foo\": \"bar baz\"}", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: " {\"foo\": \"bar baz\"}", lastEventId: "")))
     }
 
-    func testDoesNotRemoveOtherWhitespace() {
+    @Test func doesNotRemoveOtherWhitespace() {
         parser.parse(line: "data:\t{\"foo\": \"bar baz\"}")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "\t{\"foo\": \"bar baz\"}", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "\t{\"foo\": \"bar baz\"}", lastEventId: "")))
     }
 
-    func testAllowsNoLeadingSpace() {
+    @Test func allowsNoLeadingSpace() {
         parser.parse(line: "data:{\"foo\": \"bar baz\"}")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "{\"foo\": \"bar baz\"}", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "{\"foo\": \"bar baz\"}", lastEventId: "")))
     }
 
-    func testMultipleDataDispatch() {
+    @Test func multipleDataDispatch() {
         parser.parse(line: "data: data1")
         parser.parse(line: "data: data2")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "data1\ndata2", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "data1\ndata2", lastEventId: "")))
     }
 
     // MARK: Event type tests
-    func testDispatchesMessageWithCustomEventType() {
+    @Test func dispatchesMessageWithCustomEventType() {
         parser.parse(line: "event: customEvent")
         parser.parse(line: "data: hello")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("customEvent", MessageEvent(data: "hello", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("customEvent", MessageEvent(data: "hello", lastEventId: "")))
     }
 
-    func testCustomEventTypeWithoutSpace() {
+    @Test func customEventTypeWithoutSpace() {
         parser.parse(line: "event:customEvent")
         parser.parse(line: "data: hello")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("customEvent", MessageEvent(data: "hello", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("customEvent", MessageEvent(data: "hello", lastEventId: "")))
     }
 
-    func testCustomEventAfterData() {
+    @Test func customEventAfterData() {
         parser.parse(line: "data: hello")
         parser.parse(line: "event: customEvent")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("customEvent", MessageEvent(data: "hello", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("customEvent", MessageEvent(data: "hello", lastEventId: "")))
     }
 
-    func testEmptyEventTypesDefaultToMessage() {
+    @Test func emptyEventTypesDefaultToMessage() {
         ["event", "event:", "event: "].forEach {
             parser.parse(line: $0)
             parser.parse(line: "data: foo")
             parser.parse(line: "")
         }
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "foo", lastEventId: "")))
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "foo", lastEventId: "")))
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "foo", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "foo", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "foo", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "foo", lastEventId: "")))
     }
 
-    func testDispatchWithoutDataResetsMessageType() {
+    @Test func dispatchWithoutDataResetsMessageType() {
         parser.parse(line: "event: customEvent")
         parser.parse(line: "")
         parser.parse(line: "data: foo")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "foo", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "foo", lastEventId: "")))
     }
 
-    func testDispatchWithDataResetsMessageType() {
+    @Test func dispatchWithDataResetsMessageType() {
         parser.parse(line: "event: customEvent")
         parser.parse(line: "data: foo")
         parser.parse(line: "")
         parser.parse(line: "data: bar")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("customEvent", MessageEvent(data: "foo", lastEventId: "")))
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "bar", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("customEvent", MessageEvent(data: "foo", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "bar", lastEventId: "")))
     }
 
     // MARK: Last event ID tests
-    func testLastEventIdNotReturnedUntilDispatch() {
-        XCTAssertEqual(parser.getLastEventId(), "")
+    @Test func lastEventIdNotReturnedUntilDispatch() {
+        #expect(parser.getLastEventId() == "")
         parser.parse(line: "id: 1")
-        XCTAssertNil(handler.events.maybeEvent())
-        XCTAssertEqual(parser.getLastEventId(), "")
+        #expect(handler.events.maybeEvent() == nil)
+        #expect(parser.getLastEventId() == "")
     }
 
-    func testRecordsLastEventIdWithoutData() {
+    @Test func recordsLastEventIdWithoutData() {
         parser.parse(line: "id: 1")
         parser.parse(line: "")
-        XCTAssertNil(handler.events.maybeEvent())
-        XCTAssertEqual(parser.getLastEventId(), "1")
+        #expect(handler.events.maybeEvent() == nil)
+        #expect(parser.getLastEventId() == "1")
     }
 
-    func testEventIdIncludedInMessageEvent() {
+    @Test func eventIdIncludedInMessageEvent() {
         parser.parse(line: "data: hello")
         parser.parse(line: "id: 1")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "hello", lastEventId: "1")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "hello", lastEventId: "1")))
     }
 
-    func testReusesEventIdIfNotSet() {
+    @Test func reusesEventIdIfNotSet() {
         parser.parse(line: "data: hello")
         parser.parse(line: "id: reused")
         parser.parse(line: "")
         parser.parse(line: "data: world")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "hello", lastEventId: "reused")))
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "world", lastEventId: "reused")))
-        XCTAssertEqual(parser.getLastEventId(), "reused")
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "hello", lastEventId: "reused")))
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "world", lastEventId: "reused")))
+        #expect(parser.getLastEventId() == "reused")
     }
 
-    func testEventIdSetTwiceInEvent() {
+    @Test func eventIdSetTwiceInEvent() {
         parser.parse(line: "id: abc")
         parser.parse(line: "id: def")
         parser.parse(line: "data")
-        XCTAssertEqual(parser.getLastEventId(), "")
+        #expect(parser.getLastEventId() == "")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "", lastEventId: "def")))
-        XCTAssertEqual(parser.getLastEventId(), "def")
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "", lastEventId: "def")))
+        #expect(parser.getLastEventId() == "def")
     }
 
-    func testEventIdContainingNullIgnored() {
+    @Test func eventIdContainingNullIgnored() {
         parser.parse(line: "id: reused")
         parser.parse(line: "id: abc\u{0000}def")
         parser.parse(line: "data")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "", lastEventId: "reused")))
-        XCTAssertEqual(parser.getLastEventId(), "reused")
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "", lastEventId: "reused")))
+        #expect(parser.getLastEventId() == "reused")
     }
 
-    func testResetDoesResetLastEventIdBuffer() {
+    @Test func resetDoesResetLastEventIdBuffer() {
         parser.parse(line: "id: 1")
         _ = parser.reset()
         parser.parse(line: "data: hello")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "hello", lastEventId: "")))
-        XCTAssertEqual(parser.getLastEventId(), "")
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "hello", lastEventId: "")))
+        #expect(parser.getLastEventId() == "")
     }
 
-    func testResetDoesNotResetLastEventId() {
+    @Test func resetDoesNotResetLastEventId() {
         parser.parse(line: "id: 1")
         parser.parse(line: "")
         _ = parser.reset()
         parser.parse(line: "data: hello")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("message", MessageEvent(data: "hello", lastEventId: "1")))
-        XCTAssertEqual(parser.getLastEventId(), "1")
+        #expect(handler.events.maybeEvent() == .message("message", MessageEvent(data: "hello", lastEventId: "1")))
+        #expect(parser.getLastEventId() == "1")
     }
 
     // MARK: Mixed and other tests
-    func testRepeatedEmptyLines() {
+    @Test func repeatedEmptyLines() {
         parser.parse(line: "")
         parser.parse(line: "")
         parser.parse(line: "")
-        XCTAssertNil(handler.events.maybeEvent())
+        #expect(handler.events.maybeEvent() == nil)
     }
 
-    func testNothingDoneForInvalidFieldName() {
+    @Test func nothingDoneForInvalidFieldName() {
         parser.parse(line: "invalid: bar")
-        XCTAssertNil(handler.events.maybeEvent())
+        #expect(handler.events.maybeEvent() == nil)
     }
 
-    func testInvalidFieldNameIgnoredInEvent() {
+    @Test func invalidFieldNameIgnoredInEvent() {
         parser.parse(line: "data: foo")
         parser.parse(line: "invalid: bar")
         parser.parse(line: "event: msg")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .message("msg", MessageEvent(data: "foo", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .message("msg", MessageEvent(data: "foo", lastEventId: "")))
     }
 
-    func testCommentInEvent() {
+    @Test func commentInEvent() {
         parser.parse(line: "data: foo")
         parser.parse(line: ":bar")
         parser.parse(line: "event: msg")
         parser.parse(line: "")
-        XCTAssertEqual(handler.events.maybeEvent(), .comment("bar"))
-        XCTAssertEqual(handler.events.maybeEvent(), .message("msg", MessageEvent(data: "foo", lastEventId: "")))
+        #expect(handler.events.maybeEvent() == .comment("bar"))
+        #expect(handler.events.maybeEvent() == .message("msg", MessageEvent(data: "foo", lastEventId: "")))
     }
 }

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -1,47 +1,45 @@
-import XCTest
+import Foundation
+import Testing
 @testable import LDSwiftEventSource
 
 #if os(Linux) || os(Windows)
 import FoundationNetworking
 #endif
 
-final class LDSwiftEventSourceTests: XCTestCase {
-    private var mockHandler: MockHandler!
+@Suite("LDSwiftEventSource", .serialized)
+final class LDSwiftEventSourceTests {
+    private let mockHandler = MockHandler()
 
-    override func setUp() {
-        super.setUp()
-        mockHandler = MockHandler()
-        XCTAssertTrue(URLProtocol.registerClass(MockingProtocol.self))
+    init() {
+        #expect(URLProtocol.registerClass(MockingProtocol.self))
     }
 
-    override func tearDown() {
-        super.tearDown()
+    deinit {
         URLProtocol.unregisterClass(MockingProtocol.self)
         // Enforce that tests consume all mocked network requests
         MockingProtocol.requested.expectNoEvent(within: 0.01)
         MockingProtocol.resetRequested()
         // Enforce that tests consume all calls to the mock handler
         mockHandler.events.expectNoEvent(within: 0.01)
-        mockHandler = nil
     }
 
-    func testConfigDefaults() {
+    @Test func configDefaults() {
         let url = URL(string: "abc")!
         let config = EventSource.Config(handler: mockHandler, url: url)
-        XCTAssertEqual(config.url, url)
-        XCTAssertEqual(config.method, "GET")
-        XCTAssertEqual(config.body, nil)
-        XCTAssertEqual(config.lastEventId, "")
-        XCTAssertEqual(config.headers, [:])
-        XCTAssertEqual(config.reconnectTime, 1.0)
-        XCTAssertEqual(config.maxReconnectTime, 30.0)
-        XCTAssertEqual(config.backoffResetThreshold, 60.0)
-        XCTAssertEqual(config.idleTimeout, 300.0)
-        XCTAssertEqual(config.headerTransform(["abc": "123"]), ["abc": "123"])
-        XCTAssertEqual(config.connectionErrorHandler(DummyError()), .proceed)
+        #expect(config.url == url)
+        #expect(config.method == "GET")
+        #expect(config.body == nil)
+        #expect(config.lastEventId == "")
+        #expect(config.headers == [:])
+        #expect(config.reconnectTime == 1.0)
+        #expect(config.maxReconnectTime == 30.0)
+        #expect(config.backoffResetThreshold == 60.0)
+        #expect(config.idleTimeout == 300.0)
+        #expect(config.headerTransform(["abc": "123"]) == ["abc": "123"])
+        #expect(config.connectionErrorHandler(DummyError()) == .proceed)
     }
 
-    func testConfigModification() {
+    @Test func configModification() {
         let url = URL(string: "abc")!
         var config = EventSource.Config(handler: mockHandler, url: url)
 
@@ -59,67 +57,67 @@ final class LDSwiftEventSourceTests: XCTestCase {
         config.headerTransform = { _ in [:] }
         config.connectionErrorHandler = { _ in .shutdown }
 
-        XCTAssertEqual(config.url, url)
-        XCTAssertEqual(config.method, "REPORT")
-        XCTAssertEqual(config.body, testBody)
-        XCTAssertEqual(config.lastEventId, "eventId")
-        XCTAssertEqual(config.headers, testHeaders)
-        XCTAssertEqual(config.headerTransform(config.headers), [:])
-        XCTAssertEqual(config.reconnectTime, 2.0)
-        XCTAssertEqual(config.maxReconnectTime, 60.0)
-        XCTAssertEqual(config.backoffResetThreshold, 120.0)
-        XCTAssertEqual(config.idleTimeout, 180.0)
-        XCTAssertEqual(config.connectionErrorHandler(DummyError()), .shutdown)
+        #expect(config.url == url)
+        #expect(config.method == "REPORT")
+        #expect(config.body == testBody)
+        #expect(config.lastEventId == "eventId")
+        #expect(config.headers == testHeaders)
+        #expect(config.headerTransform(config.headers) == [:])
+        #expect(config.reconnectTime == 2.0)
+        #expect(config.maxReconnectTime == 60.0)
+        #expect(config.backoffResetThreshold == 120.0)
+        #expect(config.idleTimeout == 180.0)
+        #expect(config.connectionErrorHandler(DummyError()) == .shutdown)
     }
 
-    func testConfigUrlSession() {
+    @Test func configUrlSession() {
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "abc")!)
         let defaultSessionConfig = config.urlSessionConfiguration
-        XCTAssertEqual(defaultSessionConfig.timeoutIntervalForRequest, 300.0)
-        XCTAssertEqual(defaultSessionConfig.httpAdditionalHeaders?["Accept"] as? String, "text/event-stream")
-        XCTAssertEqual(defaultSessionConfig.httpAdditionalHeaders?["Cache-Control"] as? String, "no-cache")
+        #expect(defaultSessionConfig.timeoutIntervalForRequest == 300.0)
+        #expect(defaultSessionConfig.httpAdditionalHeaders?["Accept"] as? String == "text/event-stream")
+        #expect(defaultSessionConfig.httpAdditionalHeaders?["Cache-Control"] as? String == "no-cache")
         // Configuration should return a fresh session configuration each retrieval
-        XCTAssertTrue(defaultSessionConfig !== config.urlSessionConfiguration)
+        #expect(defaultSessionConfig !== config.urlSessionConfiguration)
         // Updating idleTimeout should effect session config
         config.idleTimeout = 600.0
-        XCTAssertEqual(config.urlSessionConfiguration.timeoutIntervalForRequest, 600.0)
-        XCTAssertEqual(defaultSessionConfig.timeoutIntervalForRequest, 300.0)
+        #expect(config.urlSessionConfiguration.timeoutIntervalForRequest == 600.0)
+        #expect(defaultSessionConfig.timeoutIntervalForRequest == 300.0)
         // Updating returned urlSessionConfiguration without setting should not update the Config until set
         let sessionConfig = config.urlSessionConfiguration
         sessionConfig.allowsCellularAccess = false
-        XCTAssertTrue(config.urlSessionConfiguration.allowsCellularAccess)
+        #expect(config.urlSessionConfiguration.allowsCellularAccess)
         config.urlSessionConfiguration = sessionConfig
-        XCTAssertFalse(config.urlSessionConfiguration.allowsCellularAccess)
-        XCTAssertTrue(sessionConfig !== config.urlSessionConfiguration)
+        #expect(!config.urlSessionConfiguration.allowsCellularAccess)
+        #expect(sessionConfig !== config.urlSessionConfiguration)
     }
 
-    func testLastEventIdFromConfig() {
+    @Test func lastEventIdFromConfig() {
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "abc")!)
         var es = EventSource(config: config)
-        XCTAssertEqual(es.getLastEventId(), "")
+        #expect(es.getLastEventId() == "")
         config.lastEventId = "def"
         es = EventSource(config: config)
-        XCTAssertEqual(es.getLastEventId(), "def")
+        #expect(es.getLastEventId() == "def")
     }
 
-    func testCreatedSession() {
+    @Test func createdSession() {
         let config = EventSource.Config(handler: mockHandler, url: URL(string: "abc")!)
         let session = EventSourceDelegate(config: config).createSession()
-        XCTAssertEqual(session.configuration.timeoutIntervalForRequest, config.idleTimeout)
-        XCTAssertEqual(session.configuration.httpAdditionalHeaders?["Accept"] as? String, "text/event-stream")
-        XCTAssertEqual(session.configuration.httpAdditionalHeaders?["Cache-Control"] as? String, "no-cache")
+        #expect(session.configuration.timeoutIntervalForRequest == config.idleTimeout)
+        #expect(session.configuration.httpAdditionalHeaders?["Accept"] as? String == "text/event-stream")
+        #expect(session.configuration.httpAdditionalHeaders?["Cache-Control"] as? String == "no-cache")
     }
 
-    func testCreateRequest() {
+    @Test func createRequest() {
         // 192.0.2.1 is assigned as TEST-NET-1 reserved usage.
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://192.0.2.1")!)
         // Testing default configs
         var request = EventSourceDelegate(config: config).createRequest()
-        XCTAssertEqual(request.url, config.url)
-        XCTAssertEqual(request.httpMethod, config.method)
-        XCTAssertEqual(request.httpBody, config.body)
-        XCTAssertEqual(request.timeoutInterval, config.idleTimeout)
-        XCTAssertEqual(request.allHTTPHeaderFields, config.headers)
+        #expect(request.url == config.url)
+        #expect(request.httpMethod == config.method)
+        #expect(request.httpBody == config.body)
+        #expect(request.timeoutInterval == config.idleTimeout)
+        #expect(request.allHTTPHeaderFields == config.headers)
         // Testing customized configs
         let testBody = "test data".data(using: .utf8)
         let testHeaders = ["removing": "a", "updating": "b"]
@@ -130,18 +128,18 @@ final class LDSwiftEventSourceTests: XCTestCase {
         config.headers = testHeaders
         config.idleTimeout = 180.0
         config.headerTransform = { provided in
-            XCTAssertEqual(provided, ["removing": "a", "updating": "b", "Last-Event-Id": "eventId"])
+            #expect(provided == ["removing": "a", "updating": "b", "Last-Event-Id": "eventId"])
             return overrideHeaders
         }
         request = EventSourceDelegate(config: config).createRequest()
-        XCTAssertEqual(request.url, config.url)
-        XCTAssertEqual(request.httpMethod, config.method)
-        XCTAssertEqual(request.httpBody, config.body)
-        XCTAssertEqual(request.timeoutInterval, config.idleTimeout)
-        XCTAssertEqual(request.allHTTPHeaderFields, overrideHeaders)
+        #expect(request.url == config.url)
+        #expect(request.httpMethod == config.method)
+        #expect(request.httpBody == config.body)
+        #expect(request.timeoutInterval == config.idleTimeout)
+        #expect(request.allHTTPHeaderFields == overrideHeaders)
     }
 
-    func testDispatchError() {
+    @Test func dispatchError() {
         let connectionErrorHandlerCallCount = Box(0)
         let connectionErrorAction = Box<ConnectionErrorAction>(.proceed)
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "abc")!)
@@ -150,17 +148,17 @@ final class LDSwiftEventSourceTests: XCTestCase {
             return connectionErrorAction.value
         }
         let es = EventSourceDelegate(config: config)
-        XCTAssertEqual(es.dispatchError(error: DummyError()), .proceed)
-        XCTAssertEqual(connectionErrorHandlerCallCount.value, 1)
+        #expect(es.dispatchError(error: DummyError()) == .proceed)
+        #expect(connectionErrorHandlerCallCount.value == 1)
         guard case .error(let err) = mockHandler.events.expectEvent(), err is DummyError
         else {
-            XCTFail("handler should receive error if EventSource is not shutting down")
+            Issue.record("handler should receive error if EventSource is not shutting down")
             return
         }
         mockHandler.events.expectNoEvent()
         connectionErrorAction.value = .shutdown
-        XCTAssertEqual(es.dispatchError(error: DummyError()), .shutdown)
-        XCTAssertEqual(connectionErrorHandlerCallCount.value, 2)
+        #expect(es.dispatchError(error: DummyError()) == .shutdown)
+        #expect(connectionErrorHandlerCallCount.value == 2)
     }
 
     func sessionWithMockProtocol() -> URLSessionConfiguration {
@@ -170,23 +168,23 @@ final class LDSwiftEventSourceTests: XCTestCase {
     }
 
 #if !os(Linux) && !os(Windows)
-    func testStartDefaultRequest() {
+    @Test func startDefaultRequest() {
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         let es = EventSource(config: config)
         es.start()
         let handler = MockingProtocol.requested.expectEvent()
-        XCTAssertEqual(handler.request.url, config.url)
-        XCTAssertEqual(handler.request.httpMethod, config.method)
-        XCTAssertEqual(handler.request.httpBody, config.body)
-        XCTAssertEqual(handler.request.timeoutInterval, config.idleTimeout)
-        XCTAssertEqual(handler.request.allHTTPHeaderFields?["Accept"], "text/event-stream")
-        XCTAssertEqual(handler.request.allHTTPHeaderFields?["Cache-Control"], "no-cache")
-        XCTAssertNil(handler.request.allHTTPHeaderFields?["Last-Event-Id"])
+        #expect(handler.request.url == config.url)
+        #expect(handler.request.httpMethod == config.method)
+        #expect(handler.request.httpBody == config.body)
+        #expect(handler.request.timeoutInterval == config.idleTimeout)
+        #expect(handler.request.allHTTPHeaderFields?["Accept"] == "text/event-stream")
+        #expect(handler.request.allHTTPHeaderFields?["Cache-Control"] == "no-cache")
+        #expect(handler.request.allHTTPHeaderFields?["Last-Event-Id"] == nil)
         es.stop()
     }
 
-    func testStartRequestWithConfiguration() {
+    @Test func startRequestWithConfiguration() {
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         config.method = "REPORT"
@@ -197,18 +195,18 @@ final class LDSwiftEventSourceTests: XCTestCase {
         let es = EventSource(config: config)
         es.start()
         let handler = MockingProtocol.requested.expectEvent()
-        XCTAssertEqual(handler.request.url, config.url)
-        XCTAssertEqual(handler.request.httpMethod, config.method)
-        XCTAssertEqual(handler.request.bodyStreamAsData(), config.body)
-        XCTAssertEqual(handler.request.timeoutInterval, config.idleTimeout)
-        XCTAssertEqual(handler.request.allHTTPHeaderFields?["Accept"], "text/event-stream")
-        XCTAssertEqual(handler.request.allHTTPHeaderFields?["Cache-Control"], "no-cache")
-        XCTAssertEqual(handler.request.allHTTPHeaderFields?["Last-Event-Id"], config.lastEventId)
-        XCTAssertEqual(handler.request.allHTTPHeaderFields?["X-LD-Header"], "def")
+        #expect(handler.request.url == config.url)
+        #expect(handler.request.httpMethod == config.method)
+        #expect(handler.request.bodyStreamAsData() == config.body)
+        #expect(handler.request.timeoutInterval == config.idleTimeout)
+        #expect(handler.request.allHTTPHeaderFields?["Accept"] == "text/event-stream")
+        #expect(handler.request.allHTTPHeaderFields?["Cache-Control"] == "no-cache")
+        #expect(handler.request.allHTTPHeaderFields?["Last-Event-Id"] == config.lastEventId)
+        #expect(handler.request.allHTTPHeaderFields?["X-LD-Header"] == "def")
         es.stop()
     }
 
-    func testStartRequestIsNotReentrant() {
+    @Test func startRequestIsNotReentrant() {
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         let es = EventSource(config: config)
@@ -219,19 +217,19 @@ final class LDSwiftEventSourceTests: XCTestCase {
         es.stop()
     }
 
-    func testSuccessfulResponseOpens() {
+    @Test func successfulResponseOpens() {
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         let es = EventSource(config: config)
         es.start()
         let handler = MockingProtocol.requested.expectEvent()
         handler.respond(statusCode: 200)
-        XCTAssertEqual(mockHandler.events.expectEvent(), .opened)
+        #expect(mockHandler.events.expectEvent() == .opened)
         es.stop()
-        XCTAssertEqual(mockHandler.events.expectEvent(), .closed)
+        #expect(mockHandler.events.expectEvent() == .closed)
     }
 
-    func testLastEventIdUpdatedByEvents() {
+    @Test func lastEventIdUpdatedByEvents() {
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         config.reconnectTime = 0.1
@@ -239,22 +237,22 @@ final class LDSwiftEventSourceTests: XCTestCase {
         es.start()
         let handler = MockingProtocol.requested.expectEvent()
         handler.respond(statusCode: 200)
-        XCTAssertEqual(mockHandler.events.expectEvent(), .opened)
-        XCTAssertEqual(es.getLastEventId(), "")
+        #expect(mockHandler.events.expectEvent() == .opened)
+        #expect(es.getLastEventId() == "")
         handler.respond(didLoad: "id: abc\n\n")
         // Comment used for synchronization
         handler.respond(didLoad: ":comment\n")
-        XCTAssertEqual(mockHandler.events.expectEvent(), .comment("comment"))
-        XCTAssertEqual(es.getLastEventId(), "abc")
+        #expect(mockHandler.events.expectEvent() == .comment("comment"))
+        #expect(es.getLastEventId() == "abc")
         handler.finish()
-        XCTAssertEqual(mockHandler.events.expectEvent(), .closed)
+        #expect(mockHandler.events.expectEvent() == .closed)
         // Expect to reconnect and include new event id
         let reconnectHandler = MockingProtocol.requested.expectEvent()
-        XCTAssertEqual(reconnectHandler.request.allHTTPHeaderFields?["Last-Event-Id"], "abc")
+        #expect(reconnectHandler.request.allHTTPHeaderFields?["Last-Event-Id"] == "abc")
         es.stop()
     }
 
-    func testUsesRetryTime() {
+    @Test func usesRetryTime() {
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         // Long enough to cause a timeout if the retry time is not updated
@@ -263,30 +261,30 @@ final class LDSwiftEventSourceTests: XCTestCase {
         es.start()
         let handler = MockingProtocol.requested.expectEvent()
         handler.respond(statusCode: 200)
-        XCTAssertEqual(mockHandler.events.expectEvent(), .opened)
+        #expect(mockHandler.events.expectEvent() == .opened)
         handler.respond(didLoad: "retry: 100\n\n")
         handler.finish()
-        XCTAssertEqual(mockHandler.events.expectEvent(), .closed)
+        #expect(mockHandler.events.expectEvent() == .closed)
         // Expect to reconnect before this times out
         _ = MockingProtocol.requested.expectEvent()
         es.stop()
     }
 
-    func testCallsHandlerWithMessage() {
+    @Test func callsHandlerWithMessage() {
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         let es = EventSource(config: config)
         es.start()
         let handler = MockingProtocol.requested.expectEvent()
         handler.respond(statusCode: 200)
-        XCTAssertEqual(mockHandler.events.expectEvent(), .opened)
+        #expect(mockHandler.events.expectEvent() == .opened)
         handler.respond(didLoad: "event: custom\ndata: {}\n\n")
-        XCTAssertEqual(mockHandler.events.expectEvent(), .message("custom", MessageEvent(data: "{}")))
+        #expect(mockHandler.events.expectEvent() == .message("custom", MessageEvent(data: "{}")))
         es.stop()
-        XCTAssertEqual(mockHandler.events.expectEvent(), .closed)
+        #expect(mockHandler.events.expectEvent() == .closed)
     }
 
-    func testRetryOnInvalidResponseCode() {
+    @Test func retryOnInvalidResponseCode() {
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         config.reconnectTime = 0.1
@@ -297,25 +295,24 @@ final class LDSwiftEventSourceTests: XCTestCase {
         guard case let .error(err) = mockHandler.events.expectEvent(),
               let responseErr = err as? UnsuccessfulResponseError
         else {
-            XCTFail("Expected UnsuccessfulResponseError to be given to handler")
+            Issue.record("Expected UnsuccessfulResponseError to be given to handler")
             return
         }
-        XCTAssertEqual(responseErr.responseCode, 400)
+        #expect(responseErr.responseCode == 400)
         // Expect the client to reconnect
         _ = MockingProtocol.requested.expectEvent()
         es.stop()
     }
 
-    func testShutdownByErrorHandlerOnInitialErrorResponse() {
+    @Test func shutdownByErrorHandlerOnInitialErrorResponse() {
+        // The connectionErrorHandler runs on the URLSession delegate queue, off the
+        // test's task, so we capture what it observed and assert on the test thread.
+        let observedResponseCode = Box<Int?>(nil)
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         config.reconnectTime = 0.1
         config.connectionErrorHandler = { err in
-            if let responseErr = err as? UnsuccessfulResponseError {
-                XCTAssertEqual(responseErr.responseCode, 400)
-            } else {
-                XCTFail("Expected UnsuccessfulResponseError to be given to handler")
-            }
+            observedResponseCode.value = (err as? UnsuccessfulResponseError)?.responseCode
             return .shutdown
         }
         let es = EventSource(config: config)
@@ -327,9 +324,10 @@ final class LDSwiftEventSourceTests: XCTestCase {
         es.stop()
         // Error should not have been given to the handler
         mockHandler.events.expectNoEvent()
+        #expect(observedResponseCode.value == 400)
     }
 
-    func testShutdownByErrorHandlerOnResponseCompletionError() {
+    @Test func shutdownByErrorHandlerOnResponseCompletionError() {
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         config.reconnectTime = 0.1
@@ -340,9 +338,9 @@ final class LDSwiftEventSourceTests: XCTestCase {
         es.start()
         let handler = MockingProtocol.requested.expectEvent()
         handler.respond(statusCode: 200)
-        XCTAssertEqual(mockHandler.events.expectEvent(), .opened)
+        #expect(mockHandler.events.expectEvent() == .opened)
         handler.finishWith(error: DummyError())
-        XCTAssertEqual(mockHandler.events.expectEvent(), .closed)
+        #expect(mockHandler.events.expectEvent() == .closed)
         // Expect the client not to reconnect
         MockingProtocol.requested.expectNoEvent(within: 1.0)
         es.stop()
@@ -350,7 +348,7 @@ final class LDSwiftEventSourceTests: XCTestCase {
         mockHandler.events.expectNoEvent()
     }
 
-    func testShutdownBy204Response() {
+    @Test func shutdownBy204Response() {
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         config.reconnectTime = 0.1
@@ -368,16 +366,15 @@ final class LDSwiftEventSourceTests: XCTestCase {
         mockHandler.events.expectNoEvent()
     }
 
-    func testCanOverride204DefaultBehavior() {
+    @Test func canOverride204DefaultBehavior() {
+        // The connectionErrorHandler runs on the URLSession delegate queue, off the
+        // test's task, so we capture what it observed and assert on the test thread.
+        let observedResponseCode = Box<Int?>(nil)
         var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         config.reconnectTime = 0.1
         config.connectionErrorHandler = { err in
-            if let responseErr = err as? UnsuccessfulResponseError {
-                XCTAssertEqual(responseErr.responseCode, 204)
-            } else {
-                XCTFail("Expected UnsuccessfulResponseError to be given to handler")
-            }
+            observedResponseCode.value = (err as? UnsuccessfulResponseError)?.responseCode
             return .shutdown
         }
         let es = EventSource(config: config)
@@ -389,6 +386,7 @@ final class LDSwiftEventSourceTests: XCTestCase {
         es.stop()
         // Error should not have been given to the handler
         mockHandler.events.expectNoEvent()
+        #expect(observedResponseCode.value == 204)
     }
 #endif
 }

--- a/Tests/TestUtil.swift
+++ b/Tests/TestUtil.swift
@@ -1,4 +1,5 @@
-import XCTest
+import Foundation
+import Testing
 
 #if os(Linux) || os(Windows)
 import FoundationNetworking
@@ -27,7 +28,7 @@ final class EventSink<T>: @unchecked Sendable {
         while receivedEvents.isEmpty {
             guard condition.wait(until: deadline)
             else {
-                XCTFail("Expected mock handler to be called")
+                Issue.record("Expected mock handler to be called")
                 return (nil as T?)!
             }
         }
@@ -48,7 +49,7 @@ final class EventSink<T>: @unchecked Sendable {
             guard condition.wait(until: deadline)
             else { return }
         }
-        XCTFail("Expected no events in sink, found \(String(describing: receivedEvents.first))")
+        Issue.record("Expected no events in sink, found \(String(describing: receivedEvents.first))")
     }
 
     func reset() {

--- a/Tests/UTF8LineParserTests.swift
+++ b/Tests/UTF8LineParserTests.swift
@@ -1,108 +1,104 @@
-import XCTest
+import Foundation
+import Testing
 @testable import LDSwiftEventSource
 
-final class UTF8LineParserTests: XCTestCase {
-    var parser = UTF8LineParser()
+@Suite("UTF8LineParser")
+final class UTF8LineParserTests {
+    private let parser = UTF8LineParser()
 
-    override func setUp() {
-        super.setUp()
-        parser = UTF8LineParser()
-    }
-
-    override func tearDown() {
-        super.tearDown()
+    deinit {
         // Validate that `closeAndReset` completely resets the parser
         parser.closeAndReset()
-        XCTAssertEqual(parser.append(Data("\n".utf8)), [""])
+        #expect(parser.append(Data("\n".utf8)) == [""])
     }
 
-    // swiftlint:disable:next empty_xctest_method - Only runs test in tearDown
-    func testNoData() { }
+    // The reset invariant for a fresh, never-appended parser is checked in deinit.
+    @Test func noData() { }
 
-    func testEmptyData() {
-        XCTAssertEqual(parser.append(Data()), [])
+    @Test func emptyData() {
+        #expect(parser.append(Data()) == [])
     }
 
-    func testEmptyCrLine() {
-        XCTAssertEqual(parser.append(Data("\r".utf8)), [""])
+    @Test func emptyCrLine() {
+        #expect(parser.append(Data("\r".utf8)) == [""])
     }
 
-    func testBasicLineUnterminated() {
+    @Test func basicLineUnterminated() {
         let line = "test string"
-        XCTAssertEqual(parser.append(Data(line.utf8)), [])
+        #expect(parser.append(Data(line.utf8)) == [])
     }
 
-    func testBasicLineCr() {
+    @Test func basicLineCr() {
         let line = "test string"
         let data = Data((line + "\r").utf8)
-        XCTAssertEqual(parser.append(data), [line])
+        #expect(parser.append(data) == [line])
     }
 
-    func testBasicLineLf() {
+    @Test func basicLineLf() {
         let line = "test string"
         let data = Data((line + "\n").utf8)
-        XCTAssertEqual(parser.append(data), [line])
+        #expect(parser.append(data) == [line])
     }
 
-    func testBasicLineCrLf() {
+    @Test func basicLineCrLf() {
         let line = "test string"
         let data = Data((line + "\r\n").utf8)
-        XCTAssertEqual(parser.append(data), [line])
+        #expect(parser.append(data) == [line])
     }
 
-    func testBasicSplit() {
-        XCTAssertEqual(parser.append(Data("test ".utf8)), [])
-        XCTAssertEqual(parser.append(Data("string\r".utf8)), ["test string"])
+    @Test func basicSplit() {
+        #expect(parser.append(Data("test ".utf8)) == [])
+        #expect(parser.append(Data("string\r".utf8)) == ["test string"])
     }
 
-    func testUnicodeString() {
+    @Test func unicodeString() {
         let line = "¯\\_(ツ)_/¯0️⃣🇺🇸Z̮̞̠͙͔ͅḀ̗̞͈̻̗Ḷ͙͎̯̹̞͓G̻O̭̗̮𝓯𝓸𝔁"
-        XCTAssertEqual(parser.append(Data((line + "\n").utf8)), [line])
+        #expect(parser.append(Data((line + "\n").utf8)) == [line])
     }
 
-    func testNullCodePoint() {
+    @Test func nullCodePoint() {
         let line = "\u{0000}"
-        XCTAssertEqual(parser.append(Data((line + "\n").utf8)), [line])
+        #expect(parser.append(Data((line + "\n").utf8)) == [line])
     }
 
-    func testInvalidCharacterReplaced() {
+    @Test func invalidCharacterReplaced() {
         let line = "test✨string"
         var data = Data((line + "\n").utf8)
         // Remove 3rd and last byte of "✨"
         data.remove(at: 6)
         let expected = "test�string"
-        XCTAssertEqual(parser.append(data), [expected])
+        #expect(parser.append(data) == [expected])
     }
 
     // Simulates a multi-code-unit code point being split across received chunks from the network.
-    func testCodePointSplitNotReplaced() {
+    @Test func codePointSplitNotReplaced() {
         let line = "test✨string"
         let data = Data((line + "\r").utf8)
         let data1 = data.subdata(in: 0..<6)
         let data2 = data.subdata(in: 6..<14)
-        XCTAssertEqual(parser.append(data1), [])
-        XCTAssertEqual(parser.append(data2), [line])
+        #expect(parser.append(data1) == [])
+        #expect(parser.append(data2) == [line])
     }
 
     // Simulates the stream dropping part way through a multi-code-unit code point.
-    func testResetAfterPartialInvalid() {
+    @Test func resetAfterPartialInvalid() {
         var data = Data("test✨".utf8)
         data.remove(at: 6)
-        XCTAssertEqual(parser.append(data), [])
+        #expect(parser.append(data) == [])
     }
 
-    func testInvalidCharacterReplacedOnNextLineAfterCr() {
+    @Test func invalidCharacterReplacedOnNextLineAfterCr() {
         let line = "test\r✨string\r"
         var data = Data(line.utf8)
         // Remove 3rd and last byte of "✨"
         data.remove(at: 7)
-        XCTAssertEqual(parser.append(data), ["test", "�string"])
+        #expect(parser.append(data) == ["test", "�string"])
     }
 
-    func testMultiLineDataMixedLineEnding() {
+    @Test func multiLineDataMixedLineEnding() {
         let line = "test1\rtest2\ntest3\r\ntest4\r\rtest5\n\n"
         let data = Data(line.utf8)
         let expected = ["test1", "test2", "test3", "test4", "", "test5", ""]
-        XCTAssertEqual(parser.append(data), expected)
+        #expect(parser.append(data) == expected)
     }
 }


### PR DESCRIPTION
Ports the test suite to swift-testing (@Suite/@Test/#expect) to align with
swift-core, which uses swift-testing throughout. No behavior or coverage change:
same assertions and the same network-mock scenarios.

- Convert UTF8LineParserTests, EventParserTests, and LDSwiftEventSourceTests from
  XCTestCase subclasses to @Suite types. setUp/tearDown become init/deinit on
  final-class suites so the "reset works" / "no leftover events or requests"
  invariants are still enforced after each test (verified that an issue recorded
  in deinit is attributed to the owning test).
- Mark LDSwiftEventSourceTests .serialized: it shares process-global state
  (URLProtocol registration and the static MockingProtocol.requested sink), which
  XCTest ran serially and swift-testing would otherwise parallelize. The parser
  suites use per-test fixtures and stay parallel-safe.
- The connectionErrorHandler runs on the URLSession delegate queue, off the test's
  task, where swift-testing's task-local current-test is not set. Capture what it
  observes into a lock-protected Box and assert on the test thread instead of
  calling #expect from the callback.
- EventSink swaps XCTFail for Issue.record; it keeps its NSCondition blocking
  wait, which remains the right fit for the URLProtocol delegate-thread handoff.
- Drop the xcpretty pipe from the macOS SwiftPM test action: xcpretty parses
  XCTest output, not swift-testing, and piping through it without pipefail would
  garble output and mask failures. Plain `swift test` gates correctly and prints
  swift-testing's native output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tests and CI wiring; production EventSource behavior is not modified.
> 
> **Overview**
> Moves the SwiftPM test suite from **XCTest** to **swift-testing** (`@Suite` / `@Test` / `#expect`) with the same scenarios and assertions; **library code is unchanged**.
> 
> Suites replace `setUp`/`tearDown` with **`init`/`deinit`** on final classes so cleanup checks (e.g. no leftover mock events) still run per test. **`LDSwiftEventSourceTests`** is marked **`.serialized`** because it shares process-global `URLProtocol` registration and a static mock request sink that XCTest ran serially but swift-testing would parallelize.
> 
> Tests that assert inside **`connectionErrorHandler`** (URLSession delegate queue) now **capture observations in a `Box`** and `#expect` on the test thread instead of asserting from the callback. **`EventSink`** reports failures via **`Issue.record`** instead of `XCTFail`.
> 
> The **SwiftPM GitHub action** runs plain **`swift test`** instead of piping through **xcpretty**, which only understood XCTest output and could hide failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69aff96335ac0fda892f8d8b1a2bf1e85a70f873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->