### PR TITLE
feat!: AsyncSequence-first public API

### DIFF
--- a/ContractTestService/Sources/ContractTestService/main.swift
+++ b/ContractTestService/Sources/ContractTestService/main.swift
@@ -19,7 +19,7 @@ struct CreateStreamReq: Decodable {
     let body: String?
 
     func createEventSourceConfig() -> EventSource.Config {
-        var esConfig = EventSource.Config(handler: CallbackHandler(baseUrl: callbackUrl), url: streamUrl)
+        var esConfig = EventSource.Config(url: streamUrl)
         if let initialDelayMs = initialDelayMs { esConfig.reconnectTime = Double(initialDelayMs) / 1000.0 }
         if let readTimeoutMs = readTimeoutMs { esConfig.idleTimeout = Double(readTimeoutMs) / 1000.0 }
         if let lastEventId = lastEventId { esConfig.lastEventId = lastEventId }
@@ -30,7 +30,9 @@ struct CreateStreamReq: Decodable {
     }
 }
 
-class CallbackHandler: EventHandler {
+// Consumes an `EventSource`'s event stream and forwards each event to the test harness's
+// callback URL as a numbered POST, per the SSE contract-test protocol.
+struct CallbackForwarder: Sendable {
     struct EventPayloadEvent: Encodable {
         let type: String
         let data: String
@@ -52,33 +54,31 @@ class CallbackHandler: EventHandler {
     }
 
     let baseUrl: URL
-    var count = 0
 
-    init(baseUrl: URL) {
-        self.baseUrl = baseUrl
+    func consume(_ stream: AsyncStream<EventSourceEvent>) async {
+        var count = 0
+        for await event in stream {
+            switch event {
+            case .opened, .closed:
+                continue
+            case let .message(eventType, msg):
+                count += 1
+                sendUpdate(count, EventPayload(event: EventPayloadEvent(type: eventType, data: msg.data, id: msg.lastEventId)))
+            case let .comment(comment):
+                count += 1
+                sendUpdate(count, CommentPayload(comment: comment))
+            case .error:
+                count += 1
+                sendUpdate(count, ErrorPayload())
+            }
+        }
     }
 
-    func onOpened() { }
-    func onClosed() { }
-
-    func sendUpdate<T: Encodable>(_ update: T) {
-        count += 1
+    func sendUpdate<T: Encodable>(_ count: Int, _ update: T) {
         var request = URLRequest(url: baseUrl.appendingPathComponent(String(count), isDirectory: false))
         request.httpMethod = "POST"
         let data = try! JSONEncoder().encode(update)
         URLSession.shared.uploadTask(with: request, from: data) { _, _, _ in }.resume()
-    }
-
-    func onMessage(eventType type: String, messageEvent msg: MessageEvent) {
-        sendUpdate(EventPayload(event: EventPayloadEvent(type: type, data: msg.data, id: msg.lastEventId)))
-    }
-
-    func onComment(comment: String) {
-        sendUpdate(CommentPayload(comment: comment))
-    }
-
-    func onError(error: Error) {
-        sendUpdate(ErrorPayload())
     }
 }
 
@@ -106,11 +106,15 @@ router.post("/") { req, resp, next in
         return next()
     }
     let es = EventSource(config: createStreamReq.createEventSourceConfig())
+    let forwarder = CallbackForwarder(baseUrl: createStreamReq.callbackUrl)
+    let stream = es.events
     let location: String = stateQueue.sync {
         state[String(nextId)] = es
         nextId += 1
         return "/control/\(nextId - 1)"
     }
+    // The consumer task drains the stream until `es.stop()` finishes it.
+    Task { await forwarder.consume(stream) }
     es.start()
     resp.headers["Location"] = location
     resp.send(["message": "Created test service entity at \(location)"])

--- a/README.md
+++ b/README.md
@@ -25,6 +25,38 @@ dependencies: [
 ```
 <!-- x-release-please-end -->
 
+## Usage
+
+`EventSource` exposes received events as an `AsyncSequence`. Configure it with a `URL`, call `start()`, and iterate `events`:
+
+```swift
+import LDSwiftEventSource
+
+let config = EventSource.Config(url: URL(string: "https://example.com/stream")!)
+let eventSource = EventSource(config: config)
+eventSource.start()
+
+for await event in eventSource.events {
+    switch event {
+    case let .opened(headers):
+        // Connection (re)established. `headers` are the response headers, keys lowercased.
+        print("opened: \(headers)")
+    case .closed:
+        print("connection closed; the client will reconnect")
+    case let .message(eventType, message):
+        print("\(eventType): \(message.data)")
+    case let .comment(comment):
+        print("comment: \(comment)")
+    case let .error(error):
+        // Recoverable errors are advisory — the client keeps retrying and the stream stays open.
+        // An unrecoverable error is the last event before the stream finishes.
+        print("error (status: \(error.statusCode.map(String.init) ?? "none"), recoverable: \(error.recoverable))")
+    }
+}
+```
+
+The sequence is single-consumer: iterate it from one task. Call `stop()` to shut the client down and finish the stream; the connection is also torn down if the consuming task is cancelled. Errors are reported as values on the stream rather than thrown, so a recoverable failure does not interrupt iteration.
+
 ## Contributing
 
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](https://github.com/LaunchDarkly/swift-eventsource/blob/main/CONTRIBUTING.md) for instructions on how to contribute to this SDK.

--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -12,6 +12,16 @@ import FoundationNetworking
  */
 public final class EventSource: Sendable {
     private let esDelegate: EventSourceDelegate
+    private let stream: AsyncStream<EventSourceEvent>
+
+    /**
+     The stream of events produced by this `EventSource`.
+
+     Call `start()` to open the connection; received events and state changes are then delivered here as
+     `EventSourceEvent` values. The sequence is single-consumer and terminates only when `stop()` is called (or the
+     consuming task is cancelled). Events that arrive before iteration begins are buffered.
+     */
+    public var events: AsyncStream<EventSourceEvent> { stream }
 
     /**
      Initialize the `EventSource` client with the given configuration.
@@ -19,20 +29,27 @@ public final class EventSource: Sendable {
      - Parameter config: The configuration for initializing the `EventSource` client.
      */
     public init(config: Config) {
-        esDelegate = EventSourceDelegate(config: config)
+        let (stream, continuation) = AsyncStream.makeStream(of: EventSourceEvent.self)
+        self.stream = stream
+        let delegate = EventSourceDelegate(config: config, continuation: continuation)
+        self.esDelegate = delegate
+        // If the consumer stops iterating (its task is cancelled or the stream is dropped) without calling stop(),
+        // tear the connection down.
+        continuation.onTermination = { _ in delegate.stop() }
     }
 
     /**
      Start the `EventSource` client.
 
-     This will initiate a streaming connection to the configured URL. The application will be informed of received
-     events and state changes using the configured `EventHandler`.
+     This will initiate a streaming connection to the configured URL. Received events and state changes are
+     delivered through the `events` sequence.
      */
     public func start() {
         esDelegate.start()
     }
 
-    /// Shuts down the `EventSource` client. It is not valid to restart the client after calling this function.
+    /// Shuts down the `EventSource` client and finishes the `events` stream. It is not valid to restart the client
+    /// after calling this function.
     public func stop() {
         esDelegate.stop()
     }
@@ -43,8 +60,6 @@ public final class EventSource: Sendable {
 
     /// Struct for configuring the EventSource.
     public struct Config {
-        /// The `EventHandler` called in response to activity on the stream.
-        public let handler: EventHandler
         /// The `URL` of the request used when connecting to the EventSource API.
         public let url: URL
 
@@ -124,9 +139,8 @@ public final class EventSource: Sendable {
             return .proceed
         }
 
-        /// Create a new configuration with an `EventHandler` and a `URL`
-        public init(handler: EventHandler, url: URL) {
-            self.handler = handler
+        /// Create a new configuration with the `URL` to connect to.
+        public init(url: URL) {
             self.url = url
         }
     }
@@ -165,6 +179,8 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
     private let logger: Logging.Logger
 
     private let config: EventSource.Config
+    private let handler: EventHandler
+    private let continuation: AsyncStream<EventSourceEvent>.Continuation
 
     private var readyState: ReadyState = .raw {
         didSet {
@@ -178,11 +194,14 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
     private var urlSession: URLSession?
     private var sessionTask: URLSessionDataTask?
 
-    init(config: EventSource.Config) {
+    init(config: EventSource.Config, continuation: AsyncStream<EventSourceEvent>.Continuation) {
         self.config = config
         self.logger = config.logger
+        self.continuation = continuation
 
-        self.eventParser = EventParser(handler: config.handler,
+        let handler = ContinuationEventHandler(continuation: continuation)
+        self.handler = handler
+        self.eventParser = EventParser(handler: handler,
                                        initialEventId: config.lastEventId,
                                        initialRetry: config.reconnectTime)
         self.reconnectionTimer = ReconnectionTimer(maxDelay: config.maxReconnectTime,
@@ -210,10 +229,11 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
             self.readyState = .shutdown
             self.sessionTask?.cancel()
             if previousState == .open {
-                self.config.handler.onClosed()
+                self.handler.onClosed()
             }
             self.urlSession?.invalidateAndCancel()
             self.urlSession = nil
+            self.continuation.finish()
         }
     }
 
@@ -250,7 +270,7 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
     func dispatchError(error: Error) -> ConnectionErrorAction {
         let action: ConnectionErrorAction = config.connectionErrorHandler(error)
         if action != .shutdown {
-            config.handler.onError(error: error)
+            handler.onError(error: error)
         }
         return action
     }
@@ -273,9 +293,10 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
                 if dispatchError(error: error) == .shutdown {
                     logger.info("Connection has been explicitly shut down by error handler")
                     if readyState == .open {
-                        config.handler.onClosed()
+                        handler.onClosed()
                     }
                     readyState = .shutdown
+                    continuation.finish()
                     return
                 }
             }
@@ -284,7 +305,7 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
         }
 
         if readyState == .open {
-            config.handler.onClosed()
+            handler.onClosed()
         }
 
         readyState = .closed
@@ -314,13 +335,14 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
         if (200..<300).contains(statusCode) && statusCode != 204 {
             reconnectionTimer.connectedTime = Date()
             readyState = .open
-            config.handler.onOpened()
+            handler.onOpened()
             completionHandler(.allow)
         } else {
             logger.info("Unsuccessful response: \(statusCode)")
             if dispatchError(error: UnsuccessfulResponseError(responseCode: statusCode)) == .shutdown {
                 logger.info("Connection has been explicitly shut down by error handler")
                 readyState = .shutdown
+                continuation.finish()
             }
             completionHandler(.cancel)
         }
@@ -329,4 +351,23 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
     public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         utf8LineParser.append(data).forEach(eventParser.parse)
     }
+}
+
+// MARK: ContinuationEventHandler
+// Internal adapter that forwards the delegate's and EventParser's callbacks into the public
+// `EventSource.events` stream.
+final class ContinuationEventHandler: EventHandler {
+    private let continuation: AsyncStream<EventSourceEvent>.Continuation
+
+    init(continuation: AsyncStream<EventSourceEvent>.Continuation) {
+        self.continuation = continuation
+    }
+
+    func onOpened() { continuation.yield(.opened) }
+    func onClosed() { continuation.yield(.closed) }
+    func onMessage(eventType: String, messageEvent: MessageEvent) {
+        continuation.yield(.message(eventType: eventType, messageEvent))
+    }
+    func onComment(comment: String) { continuation.yield(.comment(comment)) }
+    func onError(error: Error) { continuation.yield(.error(error)) }
 }

--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -18,8 +18,8 @@ public final class EventSource: Sendable {
      The stream of events produced by this `EventSource`.
 
      Call `start()` to open the connection; received events and state changes are then delivered here as
-     `EventSourceEvent` values. The sequence terminates only when `stop()` is called (or the consuming task is
-     cancelled).
+     `EventSourceEvent` values. The sequence terminates when `stop()` is called, when the consuming task is
+     cancelled, or after an unrecoverable `.error` (refer to `EventSourceError.recoverable`).
 
      - Important:
         This is a **single-consumer** sequence: iterate it from exactly one task. Iterating it more than once
@@ -145,21 +145,13 @@ public final class EventSource: Sendable {
         }
 
         /**
-         An error handler that is called when an error occurs and can shut down the client in response.
+         An optional override of the client's error policy.
 
-         The default error handler will always attempt to reconnect on an
-         error, unless `EventSource.stop()` is called or the error code is 204.
+         The client classifies failures itself (recoverable HTTP statuses — 5xx, 400, 408, 429 — are retried; any
+         other status, including 204, is terminal). The default handler defers to that policy for every error; return
+         `.shutdown` to force an otherwise-recoverable failure to be terminal instead.
          */
-        public var connectionErrorHandler: ConnectionErrorHandler = { error in
-            guard let unsuccessfulResponseError = error as? UnsuccessfulResponseError
-            else { return .proceed }
-
-            let responseCode: Int = unsuccessfulResponseError.responseCode
-            if 204 == responseCode {
-                return .shutdown
-            }
-            return .proceed
-        }
+        public var connectionErrorHandler: ConnectionErrorHandler = { _ in .proceed }
 
         /// Create a new configuration with the `URL` to connect to.
         public init(url: URL) {
@@ -292,12 +284,37 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
         sessionTask = task
     }
 
-    func dispatchError(error: Error) -> ConnectionErrorAction {
-        let action: ConnectionErrorAction = config.connectionErrorHandler(error)
-        if action != .shutdown {
-            handler.onError(error: error)
+    /// HTTP statuses the client retries on its own. Mirrors the classification shared with the other
+    /// LaunchDarkly SSE clients: 5xx, 400, 408, and 429 are recoverable; everything else is terminal.
+    static func isRecoverable(statusCode: Int) -> Bool {
+        (500..<600).contains(statusCode) || statusCode == 400 || statusCode == 408 || statusCode == 429
+    }
+
+    /// Flattens an `HTTPURLResponse`'s headers into a `[String: String]` with lowercased keys, so callers can
+    /// look up directive headers (e.g. `x-ld-envid`, `x-ld-fd-fallback`) without worrying about server casing.
+    static func headerFields(from response: HTTPURLResponse) -> [String: String] {
+        var headers: [String: String] = [:]
+        for (key, value) in response.allHeaderFields {
+            if let key = key as? String, let value = value as? String {
+                headers[key.lowercased()] = value
+            }
         }
-        return action
+        return headers
+    }
+
+    /// Classifies a connection failure, reports it on the stream, and returns whether the client should retry.
+    /// `statusCode`/`headers` are present for HTTP responses and absent for transport errors (which default to
+    /// recoverable). The `connectionErrorHandler` may force a terminal outcome by returning `.shutdown`.
+    func emitError(_ error: Error, statusCode: Int?, headers: [String: String]) -> Bool {
+        let statusRecoverable = statusCode.map(EventSourceDelegate.isRecoverable) ?? true
+        let recoverable = statusRecoverable && config.connectionErrorHandler(error) != .shutdown
+        handler.onError(EventSourceError(
+            statusCode: statusCode,
+            headers: headers,
+            recoverable: recoverable,
+            underlyingError: statusCode == nil ? error : nil
+        ))
+        return recoverable
     }
 
     // MARK: URLSession Delegates
@@ -315,8 +332,10 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
         if let error = error {
             if (error as NSError).code != NSURLErrorCancelled {
                 logger.info("Connection error: \(error.localizedDescription)")
-                if dispatchError(error: error) == .shutdown {
-                    logger.info("Connection has been explicitly shut down by error handler")
+                // Transport errors carry no HTTP status, so they default to recoverable unless the
+                // connectionErrorHandler forces a shutdown.
+                if !emitError(error, statusCode: nil, headers: [:]) {
+                    logger.info("Connection has been shut down: error reported as unrecoverable")
                     if readyState == .open {
                         handler.onClosed()
                     }
@@ -357,15 +376,20 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
         // swiftlint:disable:next force_cast
         let httpResponse = response as! HTTPURLResponse
         let statusCode = httpResponse.statusCode
+        let headers = EventSourceDelegate.headerFields(from: httpResponse)
         if (200..<300).contains(statusCode) && statusCode != 204 {
             reconnectionTimer.connectedTime = Date()
             readyState = .open
-            handler.onOpened()
+            handler.onOpened(headers: headers)
             completionHandler(.allow)
         } else {
             logger.info("Unsuccessful response: \(statusCode)")
-            if dispatchError(error: UnsuccessfulResponseError(responseCode: statusCode)) == .shutdown {
-                logger.info("Connection has been explicitly shut down by error handler")
+            // The error (with status, headers, and recoverable flag) is reported on the stream either way.
+            // An unrecoverable status ends the stream; a recoverable one is left to the reconnect path
+            // (the cancelled task completes through didCompleteWithError, which schedules the retry).
+            let error = UnsuccessfulResponseError(responseCode: statusCode)
+            if !emitError(error, statusCode: statusCode, headers: headers) {
+                logger.info("Connection has been shut down: status \(statusCode) reported as unrecoverable")
                 readyState = .shutdown
                 continuation.finish()
             }
@@ -388,11 +412,11 @@ final class ContinuationEventHandler: EventHandler {
         self.continuation = continuation
     }
 
-    func onOpened() { continuation.yield(.opened) }
+    func onOpened(headers: [String: String]) { continuation.yield(.opened(headers: headers)) }
     func onClosed() { continuation.yield(.closed) }
     func onMessage(eventType: String, messageEvent: MessageEvent) {
         continuation.yield(.message(eventType: eventType, messageEvent))
     }
     func onComment(comment: String) { continuation.yield(.comment(comment)) }
-    func onError(error: Error) { continuation.yield(.error(error)) }
+    func onError(_ error: EventSourceError) { continuation.yield(.error(error)) }
 }

--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -18,8 +18,20 @@ public final class EventSource: Sendable {
      The stream of events produced by this `EventSource`.
 
      Call `start()` to open the connection; received events and state changes are then delivered here as
-     `EventSourceEvent` values. The sequence is single-consumer and terminates only when `stop()` is called (or the
-     consuming task is cancelled). Events that arrive before iteration begins are buffered.
+     `EventSourceEvent` values. The sequence terminates only when `stop()` is called (or the consuming task is
+     cancelled).
+
+     - Important:
+        This is a **single-consumer** sequence: iterate it from exactly one task. Iterating it more than once
+        splits events between the iterators rather than delivering each event to all of them.
+
+     - Important:
+        The stream is **unbounded** and applies no backpressure to the network. The consumer is expected to drain
+        it continuously; events parsed off the connection are buffered until iterated, so a consumer that pauses,
+        falls behind, or never iterates while the connection is open will accumulate events in memory without
+        bound. This mirrors `AsyncStream`'s default buffering and the behavior of LaunchDarkly's other
+        async-pull SSE clients; the intended consumers (an SDK's data source) process each event synchronously and
+        never fall behind.
      */
     public var events: AsyncStream<EventSourceEvent> { stream }
 
@@ -29,13 +41,23 @@ public final class EventSource: Sendable {
      - Parameter config: The configuration for initializing the `EventSource` client.
      */
     public init(config: Config) {
+        // `.unbounded` (the default) is deliberate: dropping events would corrupt last-event-id resumption, and the
+        // URLSessionDataDelegate data path cannot apply real backpressure to the socket. The consumer-must-drain
+        // contract is documented on `events`.
         let (stream, continuation) = AsyncStream.makeStream(of: EventSourceEvent.self)
         self.stream = stream
         let delegate = EventSourceDelegate(config: config, continuation: continuation)
         self.esDelegate = delegate
         // If the consumer stops iterating (its task is cancelled or the stream is dropped) without calling stop(),
-        // tear the connection down.
-        continuation.onTermination = { _ in delegate.stop() }
+        // tear the connection down. Captured weakly so the continuation does not retain the delegate (and so this
+        // EventSource); if the delegate is already gone there is nothing left to tear down.
+        continuation.onTermination = { [weak delegate] _ in delegate?.stop() }
+    }
+
+    /// Tears the connection down if this `EventSource` is deallocated without `stop()` having been called -- e.g. a
+    /// caller that creates one, never iterates `events`, and drops it. Idempotent with `stop()`.
+    deinit {
+        esDelegate.stop()
     }
 
     /**
@@ -261,6 +283,9 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
     }
 
     private func connect() {
+        // A reconnect can be scheduled (via asyncAfter) before stop() runs; once shut down, do not reopen.
+        guard readyState != .shutdown
+        else { return }
         logger.info("Starting EventSource client")
         let task = urlSession?.dataTask(with: createRequest())
         task?.resume()

--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -144,15 +144,6 @@ public final class EventSource: Sendable {
             }
         }
 
-        /**
-         An optional override of the client's error policy.
-
-         The client classifies failures itself (recoverable HTTP statuses — 5xx, 400, 408, 429 — are retried; any
-         other status, including 204, is terminal). The default handler defers to that policy for every error; return
-         `.shutdown` to force an otherwise-recoverable failure to be terminal instead.
-         */
-        public var connectionErrorHandler: ConnectionErrorHandler = { _ in .proceed }
-
         /// Create a new configuration with the `URL` to connect to.
         public init(url: URL) {
             self.url = url
@@ -303,16 +294,15 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
     }
 
     /// Classifies a connection failure, reports it on the stream, and returns whether the client should retry.
-    /// `statusCode`/`headers` are present for HTTP responses and absent for transport errors (which default to
-    /// recoverable). The `connectionErrorHandler` may force a terminal outcome by returning `.shutdown`.
-    func emitError(_ error: Error, statusCode: Int?, headers: [String: String]) -> Bool {
-        let statusRecoverable = statusCode.map(EventSourceDelegate.isRecoverable) ?? true
-        let recoverable = statusRecoverable && config.connectionErrorHandler(error) != .shutdown
+    /// An HTTP response is recoverable per `isRecoverable(statusCode:)`; a transport error (no status) defaults to
+    /// recoverable. `underlyingError` carries the transport error for the no-status case (nil for HTTP responses).
+    func emitError(statusCode: Int?, headers: [String: String], underlyingError: (any Error)?) -> Bool {
+        let recoverable = statusCode.map(EventSourceDelegate.isRecoverable) ?? true
         handler.onError(EventSourceError(
             statusCode: statusCode,
             headers: headers,
             recoverable: recoverable,
-            underlyingError: statusCode == nil ? error : nil
+            underlyingError: underlyingError
         ))
         return recoverable
     }
@@ -332,9 +322,8 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
         if let error = error {
             if (error as NSError).code != NSURLErrorCancelled {
                 logger.info("Connection error: \(error.localizedDescription)")
-                // Transport errors carry no HTTP status, so they default to recoverable unless the
-                // connectionErrorHandler forces a shutdown.
-                if !emitError(error, statusCode: nil, headers: [:]) {
+                // Transport errors carry no HTTP status, so they are always recoverable.
+                if !emitError(statusCode: nil, headers: [:], underlyingError: error) {
                     logger.info("Connection has been shut down: error reported as unrecoverable")
                     if readyState == .open {
                         handler.onClosed()
@@ -387,8 +376,7 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
             // The error (with status, headers, and recoverable flag) is reported on the stream either way.
             // An unrecoverable status ends the stream; a recoverable one is left to the reconnect path
             // (the cancelled task completes through didCompleteWithError, which schedules the retry).
-            let error = UnsuccessfulResponseError(responseCode: statusCode)
-            if !emitError(error, statusCode: statusCode, headers: headers) {
+            if !emitError(statusCode: statusCode, headers: headers, underlyingError: nil) {
                 logger.info("Connection has been shut down: status \(statusCode) reported as unrecoverable")
                 readyState = .shutdown
                 continuation.finish()

--- a/Source/Types.swift
+++ b/Source/Types.swift
@@ -1,34 +1,10 @@
 import Foundation
 
 /**
- Type for a function that can override how the `EventSource` client reacts to a connection failure.
-
- The client classifies failures itself: an HTTP response with a recoverable status (5xx, 400, 408, 429) is retried with
- backoff, and any other status — or a `ConnectionErrorHandler` returning `.shutdown` — is terminal. This handler is an
- optional override of that policy: returning `.shutdown` forces an otherwise-recoverable failure to be terminal. The
- error is reported on the `EventSource.events` stream either way (with `recoverable` reflecting the final decision).
-*/
-public typealias ConnectionErrorHandler = @Sendable (Error) -> ConnectionErrorAction
-
-/**
  Type for a function that will take in the current HTTP headers and return a new set of HTTP headers to be used when
  connecting and reconnecting to a stream.
  */
 public typealias HeaderTransform = @Sendable ([String: String]) -> [String: String]
-
-/// Potential actions a `ConnectionErrorHandler` can return.
-public enum ConnectionErrorAction: Sendable {
-    /**
-     Defer to the client's default policy: the failure is retried if its status is recoverable, otherwise it is
-     terminal. The error is reported on the `events` stream regardless.
-     */
-    case proceed
-    /**
-     Force the failure to be terminal: the client stops and does not retry. The error is still reported on the
-     `events` stream (with `recoverable == false`), immediately after which the stream finishes.
-     */
-    case shutdown
-}
 
 /// Struct representing received event from the stream.
 public struct MessageEvent: Equatable, Hashable, Sendable {
@@ -160,19 +136,4 @@ public enum ReadyState: String, Equatable, Sendable {
     case closed
     /// The connection has been permanently closed and the `EventSource` not reconnect.
     case shutdown
-}
-
-/// Error class that indicates the remote server returned an unsuccessful HTTP response code.
-public final class UnsuccessfulResponseError: Error, Sendable {
-    /// The HTTP response code received.
-    public let responseCode: Int
-
-    /**
-     Constructor for an `UnsuccessfulResponseError`.
-
-     - Parameter responseCode: The HTTP response code of the unsuccessful response.
-     */
-    public init(responseCode: Int) {
-        self.responseCode = responseCode
-    }
 }

--- a/Source/Types.swift
+++ b/Source/Types.swift
@@ -1,10 +1,12 @@
 import Foundation
 
 /**
- Type for a function that will be notified when the `EventSource` client encounters a connection failure.
+ Type for a function that can override how the `EventSource` client reacts to a connection failure.
 
- This is different from `EventHandler.onError(error:)` in that it will not be called for other kinds of errors; also,
- it has the ability to tell the client to stop reconnecting by returning a `ConnectionErrorAction.shutdown`.
+ The client classifies failures itself: an HTTP response with a recoverable status (5xx, 400, 408, 429) is retried with
+ backoff, and any other status — or a `ConnectionErrorHandler` returning `.shutdown` — is terminal. This handler is an
+ optional override of that policy: returning `.shutdown` forces an otherwise-recoverable failure to be terminal. The
+ error is reported on the `EventSource.events` stream either way (with `recoverable` reflecting the final decision).
 */
 public typealias ConnectionErrorHandler = @Sendable (Error) -> ConnectionErrorAction
 
@@ -14,16 +16,16 @@ public typealias ConnectionErrorHandler = @Sendable (Error) -> ConnectionErrorAc
  */
 public typealias HeaderTransform = @Sendable ([String: String]) -> [String: String]
 
-/// Potential actions a `ConnectionErrorHandler` can return
+/// Potential actions a `ConnectionErrorHandler` can return.
 public enum ConnectionErrorAction: Sendable {
     /**
-     Specifies that the error should be logged normally and dispatched to the `EventHandler`. Connection retrying will
-     proceed normally if appropriate.
+     Defer to the client's default policy: the failure is retried if its status is recoverable, otherwise it is
+     terminal. The error is reported on the `events` stream regardless.
      */
     case proceed
     /**
-     Specifies that the connection should be immediately shut down and not retried. The error will not be dispatched
-     to the `EventHandler`
+     Force the failure to be terminal: the client stops and does not retry. The error is still reported on the
+     `events` stream (with `recoverable == false`), immediately after which the stream finishes.
      */
     case shutdown
 }
@@ -47,10 +49,53 @@ public struct MessageEvent: Equatable, Hashable, Sendable {
     }
 }
 
+/**
+ An error reported on the `EventSource.events` stream.
+
+ Carries enough for a consumer to decide what the failure means without inspecting connection internals:
+ - `recoverable == true`: the client has scheduled a reconnect with backoff. The stream stays open; this error is
+   advisory (act on it, or ignore it and let the retry run).
+ - `recoverable == false`: the client will not retry. This error is the last event before the stream finishes.
+
+ The `headers` may carry service directives (e.g. an FDv1-fallback instruction) even on an error response, so they are
+ load-bearing rather than diagnostic.
+ */
+public struct EventSourceError: Error, Sendable {
+    /// The HTTP status code, when the failure was an unsuccessful HTTP response; `nil` for a transport/network error
+    /// that never produced a response.
+    public let statusCode: Int?
+    /// The response headers (keys lowercased), when the failure was an HTTP response; empty for a transport error.
+    public let headers: [String: String]
+    /// Whether the client will retry this connection itself. When `true` the stream stays open and a reconnect is
+    /// scheduled; when `false` the client stops and the stream finishes after this error.
+    public let recoverable: Bool
+    /// The underlying transport/network error, when the failure was not an HTTP response; `nil` for HTTP-status
+    /// failures (use `statusCode`).
+    public let underlyingError: (any Error)?
+
+    /// Creates an `EventSourceError`.
+    public init(
+        statusCode: Int? = nil,
+        headers: [String: String] = [:],
+        recoverable: Bool,
+        underlyingError: (any Error)? = nil
+    ) {
+        self.statusCode = statusCode
+        self.headers = headers
+        self.recoverable = recoverable
+        self.underlyingError = underlyingError
+    }
+}
+
 /// An event delivered through the `EventSource.events` stream.
 public enum EventSourceEvent: Sendable {
-    /// The stream connection has been opened.
-    case opened
+    /**
+     The stream connection has been opened.
+
+     - Parameter headers: The response headers of the connection (keys lowercased). Carries service directives such as
+       `x-ld-envid` / `x-ld-fd-fallback` that consumers may need.
+     */
+    case opened(headers: [String: String])
     /// The stream connection has been closed.
     case closed
     /**
@@ -63,19 +108,18 @@ public enum EventSourceEvent: Sendable {
     /// A comment line was received from the stream.
     case comment(String)
     /**
-     An error occurred on the network connection (including an `UnsuccessfulResponseError` if the server returns an
-     unexpected HTTP status). Delivered only after the `ConnectionErrorHandler` (if any) has processed it. This is a
-     value in the stream, not a termination: unless the error handler shuts the connection down, the client keeps
-     retrying and the stream continues. To affect the state of the connection, use a `ConnectionErrorHandler`.
+     An error occurred on the connection. This is a value in the stream, not necessarily a termination: a recoverable
+     error is advisory and the client keeps retrying, while an unrecoverable error is the last event before the stream
+     finishes. Refer to `EventSourceError.recoverable`.
      */
-    case error(any Error)
+    case error(EventSourceError)
 }
 
 /// Internal protocol for an object that receives SSE events. The public surface is the `EventSource.events`
 /// stream; conformers of this protocol feed it.
 protocol EventHandler: Sendable {
-    /// EventSource calls this method when the stream connection has been opened.
-    func onOpened()
+    /// EventSource calls this method when the stream connection has been opened, with the response headers.
+    func onOpened(headers: [String: String])
 
     /// EventSource calls this method when the stream connection has been closed.
     func onClosed()
@@ -96,14 +140,12 @@ protocol EventHandler: Sendable {
     func onComment(comment: String)
 
     /**
-     This method will be called for all exceptions that occur on the network connection (including an
-     `UnsuccessfulResponseError` if the server returns an unexpected HTTP status), but only after the
-     ConnectionErrorHandler (if any) has processed it.  If you need to do anything that affects the state of the
-     connection, use ConnectionErrorHandler.
+     EventSource calls this method when a connection failure occurs, after classifying it. The `EventSourceError`
+     carries the status code (if any), response headers, and whether the client will retry.
 
-     - Parameter error: The error received.
+     - Parameter error: The classified error.
      */
-    func onError(error: Error)
+    func onError(_ error: EventSourceError)
 }
 
 /// Enum values representing the states of an EventSource

--- a/Source/Types.swift
+++ b/Source/Types.swift
@@ -47,8 +47,33 @@ public struct MessageEvent: Equatable, Hashable, Sendable {
     }
 }
 
-/// Protocol for an object that will receive SSE events.
-public protocol EventHandler: Sendable {
+/// An event delivered through the `EventSource.events` stream.
+public enum EventSourceEvent: Sendable {
+    /// The stream connection has been opened.
+    case opened
+    /// The stream connection has been closed.
+    case closed
+    /**
+     A message was received from the stream.
+
+     - Parameter eventType: The type of the event.
+     - Parameter messageEvent: The data for the event.
+     */
+    case message(eventType: String, MessageEvent)
+    /// A comment line was received from the stream.
+    case comment(String)
+    /**
+     An error occurred on the network connection (including an `UnsuccessfulResponseError` if the server returns an
+     unexpected HTTP status). Delivered only after the `ConnectionErrorHandler` (if any) has processed it. This is a
+     value in the stream, not a termination: unless the error handler shuts the connection down, the client keeps
+     retrying and the stream continues. To affect the state of the connection, use a `ConnectionErrorHandler`.
+     */
+    case error(any Error)
+}
+
+/// Internal protocol for an object that receives SSE events. The public surface is the `EventSource.events`
+/// stream; conformers of this protocol feed it.
+protocol EventHandler: Sendable {
     /// EventSource calls this method when the stream connection has been opened.
     func onOpened()
 

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -508,9 +508,11 @@ final class LDSwiftEventSourceTests {
         handler.finishWith(error: DummyError())
         // A transport error after the connection opened; the handler forces it terminal, so it is
         // reported as unrecoverable, followed by .closed, and the stream ends without a reconnect.
+        // (URLSession wraps the delegate error into an NSError on Darwin, so assert presence, not type.)
         let err = await collector.expectError()
         #expect(err?.recoverable == false)
-        #expect(err?.underlyingError is DummyError)
+        #expect(err?.statusCode == nil)
+        #expect(err?.underlyingError != nil)
         #expect(await collector.events.expectEvent() == .closed)
         await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
         await expectFullyConsumed(collector)

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -172,7 +172,11 @@ final class LDSwiftEventSourceTests {
         return sessionConfig
     }
 
-#if !os(Linux) && !os(Windows)
+// The URLProtocol-based network tests run on Darwin and Linux. Windows is excluded
+// (the mock interception there is unverified). A few assertions and one test depend on
+// Darwin-specific URLSession/URLProtocol behavior and are further guarded with #if !os(Linux)
+// inline, with the reason noted at each site.
+#if !os(Windows)
     @Test func startDefaultRequest() async throws {
         var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
@@ -183,8 +187,12 @@ final class LDSwiftEventSourceTests {
         #expect(handler.request.httpMethod == config.method)
         #expect(handler.request.httpBody == config.body)
         #expect(handler.request.timeoutInterval == config.idleTimeout)
+#if !os(Linux)
+        // swift-corelibs-foundation does not merge the session's httpAdditionalHeaders into the
+        // request seen by URLProtocol, so the session-injected headers are only assertable on Darwin.
         #expect(handler.request.allHTTPHeaderFields?["Accept"] == "text/event-stream")
         #expect(handler.request.allHTTPHeaderFields?["Cache-Control"] == "no-cache")
+#endif
         #expect(handler.request.allHTTPHeaderFields?["Last-Event-Id"] == nil)
         es.stop()
     }
@@ -202,10 +210,19 @@ final class LDSwiftEventSourceTests {
         let handler = try #require(await MockingProtocol.requested.expectEvent())
         #expect(handler.request.url == config.url)
         #expect(handler.request.httpMethod == config.method)
+#if os(Linux)
+        // On swift-corelibs-foundation the body stays in httpBody rather than being converted to
+        // an httpBodyStream as it is on Darwin.
+        #expect(handler.request.httpBody == config.body)
+#else
         #expect(handler.request.bodyStreamAsData() == config.body)
+#endif
         #expect(handler.request.timeoutInterval == config.idleTimeout)
+#if !os(Linux)
+        // Session-injected headers are not surfaced to URLProtocol on swift-corelibs-foundation.
         #expect(handler.request.allHTTPHeaderFields?["Accept"] == "text/event-stream")
         #expect(handler.request.allHTTPHeaderFields?["Cache-Control"] == "no-cache")
+#endif
         #expect(handler.request.allHTTPHeaderFields?["Last-Event-Id"] == config.lastEventId)
         #expect(handler.request.allHTTPHeaderFields?["X-LD-Header"] == "def")
         es.stop()
@@ -297,6 +314,11 @@ final class LDSwiftEventSourceTests {
         collector.cancel()
     }
 
+    // Darwin-only: after an error response cancels the connection (completionHandler(.cancel)),
+    // swift-corelibs-foundation does not route the reconnect's data task back through the custom
+    // URLProtocol, so the reconnect request cannot be observed on Linux/Windows. (The
+    // open -> finish -> reconnect path used by other tests does work cross-platform.)
+#if !os(Linux)
     @Test func retryOnInvalidResponseCode() async throws {
         var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
@@ -318,6 +340,7 @@ final class LDSwiftEventSourceTests {
         es.stop()
         collector.cancel()
     }
+#endif
 
     @Test func shutdownByErrorHandlerOnInitialErrorResponse() async throws {
         // The connectionErrorHandler runs on the URLSession delegate queue, off the test's

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -163,6 +163,7 @@ final class LDSwiftEventSourceTests {
         #expect(es.dispatchError(error: DummyError()) == .shutdown)
         #expect(connectionErrorHandlerCallCount.value == 2)
         continuation.finish()
+        await expectFullyConsumed(collector)
         collector.cancel()
     }
 
@@ -170,6 +171,18 @@ final class LDSwiftEventSourceTests {
         let sessionConfig = URLSessionConfiguration.default
         sessionConfig.protocolClasses = [MockingProtocol.self] + (sessionConfig.protocolClasses ?? [])
         return sessionConfig
+    }
+
+    /// Enforces the suite invariant that a test consumed everything it produced: no mocked network
+    /// request and no stream event is left unobserved when the test ends.
+    ///
+    /// Must be called after the stream has been stopped/finished. It awaits the collector's drain (so
+    /// every produced event is recorded) and then checks both sinks synchronously, so the assertion is
+    /// deterministic rather than relying on a timing window.
+    private func expectFullyConsumed(_ collector: EventCollector) async {
+        await collector.drained()
+        #expect(collector.events.maybeEvent() == nil, "test left an unconsumed stream event")
+        #expect(MockingProtocol.requested.maybeEvent() == nil, "test left an unconsumed mock request")
     }
 
 // The URLProtocol-based network tests run on Darwin and Linux. Windows is excluded
@@ -181,6 +194,7 @@ final class LDSwiftEventSourceTests {
         var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
         es.start()
         let handler = try #require(await MockingProtocol.requested.expectEvent())
         #expect(handler.request.url == config.url)
@@ -195,6 +209,8 @@ final class LDSwiftEventSourceTests {
 #endif
         #expect(handler.request.allHTTPHeaderFields?["Last-Event-Id"] == nil)
         es.stop()
+        await expectFullyConsumed(collector)
+        collector.cancel()
     }
 
     @Test func startRequestWithConfiguration() async throws {
@@ -206,6 +222,7 @@ final class LDSwiftEventSourceTests {
         config.lastEventId = "abc"
         config.headers = ["X-LD-Header": "def"]
         let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
         es.start()
         let handler = try #require(await MockingProtocol.requested.expectEvent())
         #expect(handler.request.url == config.url)
@@ -226,17 +243,22 @@ final class LDSwiftEventSourceTests {
         #expect(handler.request.allHTTPHeaderFields?["Last-Event-Id"] == config.lastEventId)
         #expect(handler.request.allHTTPHeaderFields?["X-LD-Header"] == "def")
         es.stop()
+        await expectFullyConsumed(collector)
+        collector.cancel()
     }
 
     @Test func startRequestIsNotReentrant() async throws {
         var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
         es.start()
         es.start()
         _ = try #require(await MockingProtocol.requested.expectEvent())
         await MockingProtocol.requested.expectNoEvent()
         es.stop()
+        await expectFullyConsumed(collector)
+        collector.cancel()
     }
 
     @Test func successfulResponseOpens() async throws {
@@ -250,6 +272,7 @@ final class LDSwiftEventSourceTests {
         #expect(await collector.events.expectEvent() == .opened)
         es.stop()
         #expect(await collector.events.expectEvent() == .closed)
+        await expectFullyConsumed(collector)
         collector.cancel()
     }
 
@@ -275,6 +298,7 @@ final class LDSwiftEventSourceTests {
         let reconnectHandler = try #require(await MockingProtocol.requested.expectEvent())
         #expect(reconnectHandler.request.allHTTPHeaderFields?["Last-Event-Id"] == "abc")
         es.stop()
+        await expectFullyConsumed(collector)
         collector.cancel()
     }
 
@@ -295,6 +319,7 @@ final class LDSwiftEventSourceTests {
         // Expect to reconnect before this times out
         _ = try #require(await MockingProtocol.requested.expectEvent())
         es.stop()
+        await expectFullyConsumed(collector)
         collector.cancel()
     }
 
@@ -311,6 +336,53 @@ final class LDSwiftEventSourceTests {
         #expect(await collector.events.expectEvent() == .message("custom", MessageEvent(data: "{}")))
         es.stop()
         #expect(await collector.events.expectEvent() == .closed)
+        await expectFullyConsumed(collector)
+        collector.cancel()
+    }
+
+    @Test func cancellingConsumerTearsDownConnection() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
+        config.urlSessionConfiguration = sessionWithMockProtocol()
+        let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
+        es.start()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
+        handler.respond(statusCode: 200)
+        #expect(await collector.events.expectEvent() == .opened)
+        // Cancelling the only consumer fires the stream's onTermination, which tears the connection
+        // down (no explicit stop()). The mock observes this as stopLoading -> RequestHandler.stop().
+        collector.cancel()
+        let deadline = ContinuousClock.now + .seconds(1)
+        while ContinuousClock.now < deadline && !handler.stopped.value {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(handler.stopped.value)
+    }
+
+    @Test func streamContinuesAcrossReconnect() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
+        config.urlSessionConfiguration = sessionWithMockProtocol()
+        config.reconnectTime = 0.1
+        let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
+        es.start()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
+        handler.respond(statusCode: 200)
+        #expect(await collector.events.expectEvent() == .opened)
+        handler.respond(didLoad: "data: first\n\n")
+        #expect(await collector.events.expectEvent() == .message("message", MessageEvent(data: "first")))
+        handler.finish()
+        #expect(await collector.events.expectEvent() == .closed)
+        // The connection drops and reconnects; the same stream keeps delivering events. A close/error
+        // is a value in the stream, not a termination.
+        let reconnect = try #require(await MockingProtocol.requested.expectEvent())
+        reconnect.respond(statusCode: 200)
+        #expect(await collector.events.expectEvent() == .opened)
+        reconnect.respond(didLoad: "data: second\n\n")
+        #expect(await collector.events.expectEvent() == .message("message", MessageEvent(data: "second")))
+        es.stop()
+        #expect(await collector.events.expectEvent() == .closed)
+        await expectFullyConsumed(collector)
         collector.cancel()
     }
 
@@ -338,6 +410,7 @@ final class LDSwiftEventSourceTests {
         // Expect the client to reconnect
         _ = try #require(await MockingProtocol.requested.expectEvent())
         es.stop()
+        await expectFullyConsumed(collector)
         collector.cancel()
     }
 #endif
@@ -364,6 +437,7 @@ final class LDSwiftEventSourceTests {
         // Error should not have been delivered through the stream
         await collector.events.expectNoEvent()
         #expect(observedResponseCode.value == 400)
+        await expectFullyConsumed(collector)
         collector.cancel()
     }
 
@@ -387,6 +461,7 @@ final class LDSwiftEventSourceTests {
         es.stop()
         // Error should not have been delivered through the stream
         await collector.events.expectNoEvent()
+        await expectFullyConsumed(collector)
         collector.cancel()
     }
 
@@ -407,6 +482,7 @@ final class LDSwiftEventSourceTests {
         es.stop()
         // Error should not have been delivered through the stream
         await collector.events.expectNoEvent()
+        await expectFullyConsumed(collector)
         collector.cancel()
     }
 
@@ -432,6 +508,7 @@ final class LDSwiftEventSourceTests {
         // Error should not have been delivered through the stream
         await collector.events.expectNoEvent()
         #expect(observedResponseCode.value == 204)
+        await expectFullyConsumed(collector)
         collector.cancel()
     }
 #endif

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -140,7 +140,16 @@ final class LDSwiftEventSourceTests {
         #expect(request.allHTTPHeaderFields == overrideHeaders)
     }
 
-    @Test func dispatchError() async {
+    @Test func recoverableStatusClassification() {
+        for code in [500, 503, 599, 400, 408, 429] {
+            #expect(EventSourceDelegate.isRecoverable(statusCode: code), "\(code) should be recoverable")
+        }
+        for code in [200, 204, 301, 401, 403, 404] {
+            #expect(!EventSourceDelegate.isRecoverable(statusCode: code), "\(code) should not be recoverable")
+        }
+    }
+
+    @Test func emitErrorClassifiesAndReports() async {
         let connectionErrorHandlerCallCount = Box(0)
         let connectionErrorAction = Box<ConnectionErrorAction>(.proceed)
         var config = EventSource.Config(url: URL(string: "abc")!)
@@ -151,17 +160,23 @@ final class LDSwiftEventSourceTests {
         let (stream, continuation) = AsyncStream.makeStream(of: EventSourceEvent.self)
         let collector = EventCollector(stream)
         let es = EventSourceDelegate(config: config, continuation: continuation)
-        #expect(es.dispatchError(error: DummyError()) == .proceed)
+
+        // A transport error (no status) is recoverable by default; the handler is consulted and the
+        // error is reported on the stream with its underlying error preserved.
+        #expect(es.emitError(DummyError(), statusCode: nil, headers: [:]))
         #expect(connectionErrorHandlerCallCount.value == 1)
-        guard case .error(let err)? = await collector.events.expectEvent(), err is DummyError
-        else {
-            Issue.record("handler should receive error if EventSource is not shutting down")
-            return
-        }
+        let recoverableError = await collector.expectError()
+        #expect(recoverableError?.statusCode == nil)
+        #expect(recoverableError?.recoverable == true)
+        #expect(recoverableError?.underlyingError is DummyError)
         await collector.events.expectNoEvent()
+
+        // The handler can force the same error to be terminal.
         connectionErrorAction.value = .shutdown
-        #expect(es.dispatchError(error: DummyError()) == .shutdown)
+        #expect(!es.emitError(DummyError(), statusCode: nil, headers: [:]))
         #expect(connectionErrorHandlerCallCount.value == 2)
+        #expect(await collector.expectError()?.recoverable == false)
+
         continuation.finish()
         await expectFullyConsumed(collector)
         collector.cancel()
@@ -269,7 +284,7 @@ final class LDSwiftEventSourceTests {
         es.start()
         let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 200)
-        #expect(await collector.events.expectEvent() == .opened)
+        await collector.expectOpened()
         es.stop()
         #expect(await collector.events.expectEvent() == .closed)
         await expectFullyConsumed(collector)
@@ -285,7 +300,7 @@ final class LDSwiftEventSourceTests {
         es.start()
         let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 200)
-        #expect(await collector.events.expectEvent() == .opened)
+        await collector.expectOpened()
         #expect(es.getLastEventId() == "")
         handler.respond(didLoad: "id: abc\n\n")
         // Comment used for synchronization
@@ -312,7 +327,7 @@ final class LDSwiftEventSourceTests {
         es.start()
         let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 200)
-        #expect(await collector.events.expectEvent() == .opened)
+        await collector.expectOpened()
         handler.respond(didLoad: "retry: 100\n\n")
         handler.finish()
         #expect(await collector.events.expectEvent() == .closed)
@@ -331,7 +346,7 @@ final class LDSwiftEventSourceTests {
         es.start()
         let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 200)
-        #expect(await collector.events.expectEvent() == .opened)
+        await collector.expectOpened()
         handler.respond(didLoad: "event: custom\ndata: {}\n\n")
         #expect(await collector.events.expectEvent() == .message("custom", MessageEvent(data: "{}")))
         es.stop()
@@ -348,7 +363,7 @@ final class LDSwiftEventSourceTests {
         es.start()
         let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 200)
-        #expect(await collector.events.expectEvent() == .opened)
+        await collector.expectOpened()
         // Cancelling the only consumer fires the stream's onTermination, which tears the connection
         // down (no explicit stop()). The mock observes this as stopLoading -> RequestHandler.stop().
         collector.cancel()
@@ -368,7 +383,7 @@ final class LDSwiftEventSourceTests {
         es.start()
         let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 200)
-        #expect(await collector.events.expectEvent() == .opened)
+        await collector.expectOpened()
         handler.respond(didLoad: "data: first\n\n")
         #expect(await collector.events.expectEvent() == .message("message", MessageEvent(data: "first")))
         handler.finish()
@@ -377,11 +392,49 @@ final class LDSwiftEventSourceTests {
         // is a value in the stream, not a termination.
         let reconnect = try #require(await MockingProtocol.requested.expectEvent())
         reconnect.respond(statusCode: 200)
-        #expect(await collector.events.expectEvent() == .opened)
+        await collector.expectOpened()
         reconnect.respond(didLoad: "data: second\n\n")
         #expect(await collector.events.expectEvent() == .message("message", MessageEvent(data: "second")))
         es.stop()
         #expect(await collector.events.expectEvent() == .closed)
+        await expectFullyConsumed(collector)
+        collector.cancel()
+    }
+
+    @Test func openedCarriesResponseHeaders() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
+        config.urlSessionConfiguration = sessionWithMockProtocol()
+        let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
+        es.start()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
+        // Mixed-case keys to confirm they are surfaced lowercased.
+        handler.respond(statusCode: 200, headers: ["X-LD-EnvId": "env-123", "X-LD-FD-Fallback": "stream"])
+        let headers = await collector.expectOpened()
+        #expect(headers?["x-ld-envid"] == "env-123")
+        #expect(headers?["x-ld-fd-fallback"] == "stream")
+        es.stop()
+        #expect(await collector.events.expectEvent() == .closed)
+        await expectFullyConsumed(collector)
+        collector.cancel()
+    }
+
+    @Test func errorResponseCarriesStatusHeadersAndRecoverable() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
+        config.urlSessionConfiguration = sessionWithMockProtocol()
+        config.reconnectTime = 0.1
+        let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
+        es.start()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
+        // 401 is unrecoverable, so this terminates without a reconnect (observable cross-platform). The
+        // response headers must still be surfaced -- the FDv2 protocol reads directives off error responses.
+        handler.respond(statusCode: 401, headers: ["X-LD-FD-Fallback": "poll"])
+        let err = await collector.expectError()
+        #expect(err?.statusCode == 401)
+        #expect(err?.recoverable == false)
+        #expect(err?.headers["x-ld-fd-fallback"] == "poll")
+        await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
         await expectFullyConsumed(collector)
         collector.cancel()
     }
@@ -400,13 +453,10 @@ final class LDSwiftEventSourceTests {
         es.start()
         let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 400)
-        guard case .error(let err)? = await collector.events.expectEvent(),
-              let responseErr = err as? UnsuccessfulResponseError
-        else {
-            Issue.record("Expected UnsuccessfulResponseError to be given to handler")
-            return
-        }
-        #expect(responseErr.responseCode == 400)
+        // 400 is a recoverable status: the error is advisory and the client retries.
+        let err = await collector.expectError()
+        #expect(err?.statusCode == 400)
+        #expect(err?.recoverable == true)
         // Expect the client to reconnect
         _ = try #require(await MockingProtocol.requested.expectEvent())
         es.stop()
@@ -431,11 +481,12 @@ final class LDSwiftEventSourceTests {
         es.start()
         let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 400)
-        // Expect the client not to reconnect
+        // 400 is recoverable by status, but the handler forces a terminal outcome: the error is reported
+        // as unrecoverable and the stream ends without a reconnect.
+        let err = await collector.expectError()
+        #expect(err?.statusCode == 400)
+        #expect(err?.recoverable == false)
         await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
-        es.stop()
-        // Error should not have been delivered through the stream
-        await collector.events.expectNoEvent()
         #expect(observedResponseCode.value == 400)
         await expectFullyConsumed(collector)
         collector.cancel()
@@ -453,14 +504,15 @@ final class LDSwiftEventSourceTests {
         es.start()
         let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 200)
-        #expect(await collector.events.expectEvent() == .opened)
+        await collector.expectOpened()
         handler.finishWith(error: DummyError())
+        // A transport error after the connection opened; the handler forces it terminal, so it is
+        // reported as unrecoverable, followed by .closed, and the stream ends without a reconnect.
+        let err = await collector.expectError()
+        #expect(err?.recoverable == false)
+        #expect(err?.underlyingError is DummyError)
         #expect(await collector.events.expectEvent() == .closed)
-        // Expect the client not to reconnect
         await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
-        es.stop()
-        // Error should not have been delivered through the stream
-        await collector.events.expectNoEvent()
         await expectFullyConsumed(collector)
         collector.cancel()
     }
@@ -476,19 +528,18 @@ final class LDSwiftEventSourceTests {
 
         let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 204)
-
+        // 204 is not a recoverable status: it is reported as a terminal error and the stream ends.
+        let err = await collector.expectError()
+        #expect(err?.statusCode == 204)
+        #expect(err?.recoverable == false)
         await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
-
-        es.stop()
-        // Error should not have been delivered through the stream
-        await collector.events.expectNoEvent()
         await expectFullyConsumed(collector)
         collector.cancel()
     }
 
-    @Test func canOverride204DefaultBehavior() async throws {
-        // The connectionErrorHandler runs on the URLSession delegate queue, off the test's
-        // task, so we capture what it observed and assert on the test thread.
+    @Test func connectionErrorHandlerCanForceTerminal() async throws {
+        // 503 is normally recoverable; a connectionErrorHandler returning .shutdown overrides the
+        // default policy and makes the failure terminal (reported as unrecoverable, no reconnect).
         let observedResponseCode = Box<Int?>(nil)
         var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
@@ -501,13 +552,12 @@ final class LDSwiftEventSourceTests {
         let collector = EventCollector(es.events)
         es.start()
         let handler = try #require(await MockingProtocol.requested.expectEvent())
-        handler.respond(statusCode: 204)
-        // Expect the client not to reconnect
+        handler.respond(statusCode: 503)
+        let err = await collector.expectError()
+        #expect(err?.statusCode == 503)
+        #expect(err?.recoverable == false)
         await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
-        es.stop()
-        // Error should not have been delivered through the stream
-        await collector.events.expectNoEvent()
-        #expect(observedResponseCode.value == 204)
+        #expect(observedResponseCode.value == 503)
         await expectFullyConsumed(collector)
         collector.cancel()
     }

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -8,24 +8,25 @@ import FoundationNetworking
 
 @Suite("LDSwiftEventSource", .serialized)
 final class LDSwiftEventSourceTests {
-    private let mockHandler = MockHandler()
-
     init() {
         #expect(URLProtocol.registerClass(MockingProtocol.self))
+        MockingProtocol.resetRequested()
     }
 
     deinit {
         URLProtocol.unregisterClass(MockingProtocol.self)
-        // Enforce that tests consume all mocked network requests
-        MockingProtocol.requested.expectNoEvent(within: 0.01)
-        MockingProtocol.resetRequested()
-        // Enforce that tests consume all calls to the mock handler
-        mockHandler.events.expectNoEvent(within: 0.01)
+    }
+
+    // A throwaway continuation for tests that exercise the delegate directly and do not
+    // observe the event stream.
+    private func makeDelegate(_ config: EventSource.Config) -> EventSourceDelegate {
+        let (_, continuation) = AsyncStream.makeStream(of: EventSourceEvent.self)
+        return EventSourceDelegate(config: config, continuation: continuation)
     }
 
     @Test func configDefaults() {
         let url = URL(string: "abc")!
-        let config = EventSource.Config(handler: mockHandler, url: url)
+        let config = EventSource.Config(url: url)
         #expect(config.url == url)
         #expect(config.method == "GET")
         #expect(config.body == nil)
@@ -41,7 +42,7 @@ final class LDSwiftEventSourceTests {
 
     @Test func configModification() {
         let url = URL(string: "abc")!
-        var config = EventSource.Config(handler: mockHandler, url: url)
+        var config = EventSource.Config(url: url)
 
         let testBody = "test data".data(using: .utf8)
         let testHeaders = ["Authorization": "basic abc"]
@@ -71,7 +72,7 @@ final class LDSwiftEventSourceTests {
     }
 
     @Test func configUrlSession() {
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "abc")!)
+        var config = EventSource.Config(url: URL(string: "abc")!)
         let defaultSessionConfig = config.urlSessionConfiguration
         #expect(defaultSessionConfig.timeoutIntervalForRequest == 300.0)
         #expect(defaultSessionConfig.httpAdditionalHeaders?["Accept"] as? String == "text/event-stream")
@@ -92,7 +93,7 @@ final class LDSwiftEventSourceTests {
     }
 
     @Test func lastEventIdFromConfig() {
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "abc")!)
+        var config = EventSource.Config(url: URL(string: "abc")!)
         var es = EventSource(config: config)
         #expect(es.getLastEventId() == "")
         config.lastEventId = "def"
@@ -101,8 +102,8 @@ final class LDSwiftEventSourceTests {
     }
 
     @Test func createdSession() {
-        let config = EventSource.Config(handler: mockHandler, url: URL(string: "abc")!)
-        let session = EventSourceDelegate(config: config).createSession()
+        let config = EventSource.Config(url: URL(string: "abc")!)
+        let session = makeDelegate(config).createSession()
         #expect(session.configuration.timeoutIntervalForRequest == config.idleTimeout)
         #expect(session.configuration.httpAdditionalHeaders?["Accept"] as? String == "text/event-stream")
         #expect(session.configuration.httpAdditionalHeaders?["Cache-Control"] as? String == "no-cache")
@@ -110,9 +111,9 @@ final class LDSwiftEventSourceTests {
 
     @Test func createRequest() {
         // 192.0.2.1 is assigned as TEST-NET-1 reserved usage.
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://192.0.2.1")!)
+        var config = EventSource.Config(url: URL(string: "http://192.0.2.1")!)
         // Testing default configs
-        var request = EventSourceDelegate(config: config).createRequest()
+        var request = makeDelegate(config).createRequest()
         #expect(request.url == config.url)
         #expect(request.httpMethod == config.method)
         #expect(request.httpBody == config.body)
@@ -131,7 +132,7 @@ final class LDSwiftEventSourceTests {
             #expect(provided == ["removing": "a", "updating": "b", "Last-Event-Id": "eventId"])
             return overrideHeaders
         }
-        request = EventSourceDelegate(config: config).createRequest()
+        request = makeDelegate(config).createRequest()
         #expect(request.url == config.url)
         #expect(request.httpMethod == config.method)
         #expect(request.httpBody == config.body)
@@ -139,26 +140,30 @@ final class LDSwiftEventSourceTests {
         #expect(request.allHTTPHeaderFields == overrideHeaders)
     }
 
-    @Test func dispatchError() {
+    @Test func dispatchError() async {
         let connectionErrorHandlerCallCount = Box(0)
         let connectionErrorAction = Box<ConnectionErrorAction>(.proceed)
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "abc")!)
+        var config = EventSource.Config(url: URL(string: "abc")!)
         config.connectionErrorHandler = { _ in
             connectionErrorHandlerCallCount.value += 1
             return connectionErrorAction.value
         }
-        let es = EventSourceDelegate(config: config)
+        let (stream, continuation) = AsyncStream.makeStream(of: EventSourceEvent.self)
+        let collector = EventCollector(stream)
+        let es = EventSourceDelegate(config: config, continuation: continuation)
         #expect(es.dispatchError(error: DummyError()) == .proceed)
         #expect(connectionErrorHandlerCallCount.value == 1)
-        guard case .error(let err) = mockHandler.events.expectEvent(), err is DummyError
+        guard case .error(let err)? = await collector.events.expectEvent(), err is DummyError
         else {
             Issue.record("handler should receive error if EventSource is not shutting down")
             return
         }
-        mockHandler.events.expectNoEvent()
+        await collector.events.expectNoEvent()
         connectionErrorAction.value = .shutdown
         #expect(es.dispatchError(error: DummyError()) == .shutdown)
         #expect(connectionErrorHandlerCallCount.value == 2)
+        continuation.finish()
+        collector.cancel()
     }
 
     func sessionWithMockProtocol() -> URLSessionConfiguration {
@@ -168,12 +173,12 @@ final class LDSwiftEventSourceTests {
     }
 
 #if !os(Linux) && !os(Windows)
-    @Test func startDefaultRequest() {
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
+    @Test func startDefaultRequest() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         let es = EventSource(config: config)
         es.start()
-        let handler = MockingProtocol.requested.expectEvent()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
         #expect(handler.request.url == config.url)
         #expect(handler.request.httpMethod == config.method)
         #expect(handler.request.httpBody == config.body)
@@ -184,8 +189,8 @@ final class LDSwiftEventSourceTests {
         es.stop()
     }
 
-    @Test func startRequestWithConfiguration() {
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
+    @Test func startRequestWithConfiguration() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         config.method = "REPORT"
         config.body = Data("test body".utf8)
@@ -194,7 +199,7 @@ final class LDSwiftEventSourceTests {
         config.headers = ["X-LD-Header": "def"]
         let es = EventSource(config: config)
         es.start()
-        let handler = MockingProtocol.requested.expectEvent()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
         #expect(handler.request.url == config.url)
         #expect(handler.request.httpMethod == config.method)
         #expect(handler.request.bodyStreamAsData() == config.body)
@@ -206,93 +211,102 @@ final class LDSwiftEventSourceTests {
         es.stop()
     }
 
-    @Test func startRequestIsNotReentrant() {
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
+    @Test func startRequestIsNotReentrant() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         let es = EventSource(config: config)
         es.start()
         es.start()
-        _ = MockingProtocol.requested.expectEvent()
-        MockingProtocol.requested.expectNoEvent()
+        _ = try #require(await MockingProtocol.requested.expectEvent())
+        await MockingProtocol.requested.expectNoEvent()
         es.stop()
     }
 
-    @Test func successfulResponseOpens() {
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
+    @Test func successfulResponseOpens() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
         es.start()
-        let handler = MockingProtocol.requested.expectEvent()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 200)
-        #expect(mockHandler.events.expectEvent() == .opened)
+        #expect(await collector.events.expectEvent() == .opened)
         es.stop()
-        #expect(mockHandler.events.expectEvent() == .closed)
+        #expect(await collector.events.expectEvent() == .closed)
+        collector.cancel()
     }
 
-    @Test func lastEventIdUpdatedByEvents() {
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
+    @Test func lastEventIdUpdatedByEvents() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         config.reconnectTime = 0.1
         let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
         es.start()
-        let handler = MockingProtocol.requested.expectEvent()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 200)
-        #expect(mockHandler.events.expectEvent() == .opened)
+        #expect(await collector.events.expectEvent() == .opened)
         #expect(es.getLastEventId() == "")
         handler.respond(didLoad: "id: abc\n\n")
         // Comment used for synchronization
         handler.respond(didLoad: ":comment\n")
-        #expect(mockHandler.events.expectEvent() == .comment("comment"))
+        #expect(await collector.events.expectEvent() == .comment("comment"))
         #expect(es.getLastEventId() == "abc")
         handler.finish()
-        #expect(mockHandler.events.expectEvent() == .closed)
+        #expect(await collector.events.expectEvent() == .closed)
         // Expect to reconnect and include new event id
-        let reconnectHandler = MockingProtocol.requested.expectEvent()
+        let reconnectHandler = try #require(await MockingProtocol.requested.expectEvent())
         #expect(reconnectHandler.request.allHTTPHeaderFields?["Last-Event-Id"] == "abc")
         es.stop()
+        collector.cancel()
     }
 
-    @Test func usesRetryTime() {
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
+    @Test func usesRetryTime() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         // Long enough to cause a timeout if the retry time is not updated
         config.reconnectTime = 5
         let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
         es.start()
-        let handler = MockingProtocol.requested.expectEvent()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 200)
-        #expect(mockHandler.events.expectEvent() == .opened)
+        #expect(await collector.events.expectEvent() == .opened)
         handler.respond(didLoad: "retry: 100\n\n")
         handler.finish()
-        #expect(mockHandler.events.expectEvent() == .closed)
+        #expect(await collector.events.expectEvent() == .closed)
         // Expect to reconnect before this times out
-        _ = MockingProtocol.requested.expectEvent()
+        _ = try #require(await MockingProtocol.requested.expectEvent())
         es.stop()
+        collector.cancel()
     }
 
-    @Test func callsHandlerWithMessage() {
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
+    @Test func callsHandlerWithMessage() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
         es.start()
-        let handler = MockingProtocol.requested.expectEvent()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 200)
-        #expect(mockHandler.events.expectEvent() == .opened)
+        #expect(await collector.events.expectEvent() == .opened)
         handler.respond(didLoad: "event: custom\ndata: {}\n\n")
-        #expect(mockHandler.events.expectEvent() == .message("custom", MessageEvent(data: "{}")))
+        #expect(await collector.events.expectEvent() == .message("custom", MessageEvent(data: "{}")))
         es.stop()
-        #expect(mockHandler.events.expectEvent() == .closed)
+        #expect(await collector.events.expectEvent() == .closed)
+        collector.cancel()
     }
 
-    @Test func retryOnInvalidResponseCode() {
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
+    @Test func retryOnInvalidResponseCode() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         config.reconnectTime = 0.1
         let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
         es.start()
-        let handler = MockingProtocol.requested.expectEvent()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 400)
-        guard case let .error(err) = mockHandler.events.expectEvent(),
+        guard case .error(let err)? = await collector.events.expectEvent(),
               let responseErr = err as? UnsuccessfulResponseError
         else {
             Issue.record("Expected UnsuccessfulResponseError to be given to handler")
@@ -300,15 +314,16 @@ final class LDSwiftEventSourceTests {
         }
         #expect(responseErr.responseCode == 400)
         // Expect the client to reconnect
-        _ = MockingProtocol.requested.expectEvent()
+        _ = try #require(await MockingProtocol.requested.expectEvent())
         es.stop()
+        collector.cancel()
     }
 
-    @Test func shutdownByErrorHandlerOnInitialErrorResponse() {
-        // The connectionErrorHandler runs on the URLSession delegate queue, off the
-        // test's task, so we capture what it observed and assert on the test thread.
+    @Test func shutdownByErrorHandlerOnInitialErrorResponse() async throws {
+        // The connectionErrorHandler runs on the URLSession delegate queue, off the test's
+        // task, so we capture what it observed and assert on the test thread.
         let observedResponseCode = Box<Int?>(nil)
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         config.reconnectTime = 0.1
         config.connectionErrorHandler = { err in
@@ -316,61 +331,67 @@ final class LDSwiftEventSourceTests {
             return .shutdown
         }
         let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
         es.start()
-        let handler = MockingProtocol.requested.expectEvent()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 400)
         // Expect the client not to reconnect
-        MockingProtocol.requested.expectNoEvent(within: 1.0)
+        await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
         es.stop()
-        // Error should not have been given to the handler
-        mockHandler.events.expectNoEvent()
+        // Error should not have been delivered through the stream
+        await collector.events.expectNoEvent()
         #expect(observedResponseCode.value == 400)
+        collector.cancel()
     }
 
-    @Test func shutdownByErrorHandlerOnResponseCompletionError() {
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
+    @Test func shutdownByErrorHandlerOnResponseCompletionError() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         config.reconnectTime = 0.1
         config.connectionErrorHandler = { _ in
             .shutdown
         }
         let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
         es.start()
-        let handler = MockingProtocol.requested.expectEvent()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 200)
-        #expect(mockHandler.events.expectEvent() == .opened)
+        #expect(await collector.events.expectEvent() == .opened)
         handler.finishWith(error: DummyError())
-        #expect(mockHandler.events.expectEvent() == .closed)
+        #expect(await collector.events.expectEvent() == .closed)
         // Expect the client not to reconnect
-        MockingProtocol.requested.expectNoEvent(within: 1.0)
+        await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
         es.stop()
-        // Error should not have been given to the handler
-        mockHandler.events.expectNoEvent()
+        // Error should not have been delivered through the stream
+        await collector.events.expectNoEvent()
+        collector.cancel()
     }
 
-    @Test func shutdownBy204Response() {
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
+    @Test func shutdownBy204Response() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         config.reconnectTime = 0.1
 
         let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
         es.start()
 
-        let handler = MockingProtocol.requested.expectEvent()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 204)
 
-        MockingProtocol.requested.expectNoEvent(within: 1.0)
+        await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
 
         es.stop()
-        // Error should not have been given to the handler
-        mockHandler.events.expectNoEvent()
+        // Error should not have been delivered through the stream
+        await collector.events.expectNoEvent()
+        collector.cancel()
     }
 
-    @Test func canOverride204DefaultBehavior() {
-        // The connectionErrorHandler runs on the URLSession delegate queue, off the
-        // test's task, so we capture what it observed and assert on the test thread.
+    @Test func canOverride204DefaultBehavior() async throws {
+        // The connectionErrorHandler runs on the URLSession delegate queue, off the test's
+        // task, so we capture what it observed and assert on the test thread.
         let observedResponseCode = Box<Int?>(nil)
-        var config = EventSource.Config(handler: mockHandler, url: URL(string: "http://example.com")!)
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
         config.reconnectTime = 0.1
         config.connectionErrorHandler = { err in
@@ -378,15 +399,17 @@ final class LDSwiftEventSourceTests {
             return .shutdown
         }
         let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
         es.start()
-        let handler = MockingProtocol.requested.expectEvent()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
         handler.respond(statusCode: 204)
         // Expect the client not to reconnect
-        MockingProtocol.requested.expectNoEvent(within: 1.0)
+        await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
         es.stop()
-        // Error should not have been given to the handler
-        mockHandler.events.expectNoEvent()
+        // Error should not have been delivered through the stream
+        await collector.events.expectNoEvent()
         #expect(observedResponseCode.value == 204)
+        collector.cancel()
     }
 #endif
 }

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -37,7 +37,6 @@ final class LDSwiftEventSourceTests {
         #expect(config.backoffResetThreshold == 60.0)
         #expect(config.idleTimeout == 300.0)
         #expect(config.headerTransform(["abc": "123"]) == ["abc": "123"])
-        #expect(config.connectionErrorHandler(DummyError()) == .proceed)
     }
 
     @Test func configModification() {
@@ -56,7 +55,6 @@ final class LDSwiftEventSourceTests {
         config.backoffResetThreshold = 120.0
         config.idleTimeout = 180.0
         config.headerTransform = { _ in [:] }
-        config.connectionErrorHandler = { _ in .shutdown }
 
         #expect(config.url == url)
         #expect(config.method == "REPORT")
@@ -68,7 +66,6 @@ final class LDSwiftEventSourceTests {
         #expect(config.maxReconnectTime == 60.0)
         #expect(config.backoffResetThreshold == 120.0)
         #expect(config.idleTimeout == 180.0)
-        #expect(config.connectionErrorHandler(DummyError()) == .shutdown)
     }
 
     @Test func configUrlSession() {
@@ -150,32 +147,25 @@ final class LDSwiftEventSourceTests {
     }
 
     @Test func emitErrorClassifiesAndReports() async {
-        let connectionErrorHandlerCallCount = Box(0)
-        let connectionErrorAction = Box<ConnectionErrorAction>(.proceed)
-        var config = EventSource.Config(url: URL(string: "abc")!)
-        config.connectionErrorHandler = { _ in
-            connectionErrorHandlerCallCount.value += 1
-            return connectionErrorAction.value
-        }
+        let config = EventSource.Config(url: URL(string: "abc")!)
         let (stream, continuation) = AsyncStream.makeStream(of: EventSourceEvent.self)
         let collector = EventCollector(stream)
         let es = EventSourceDelegate(config: config, continuation: continuation)
 
-        // A transport error (no status) is recoverable by default; the handler is consulted and the
-        // error is reported on the stream with its underlying error preserved.
-        #expect(es.emitError(DummyError(), statusCode: nil, headers: [:]))
-        #expect(connectionErrorHandlerCallCount.value == 1)
-        let recoverableError = await collector.expectError()
-        #expect(recoverableError?.statusCode == nil)
-        #expect(recoverableError?.recoverable == true)
-        #expect(recoverableError?.underlyingError is DummyError)
+        // A transport error (no status) is recoverable; the underlying error is preserved on the stream.
+        #expect(es.emitError(statusCode: nil, headers: [:], underlyingError: DummyError()))
+        let transportError = await collector.expectError()
+        #expect(transportError?.statusCode == nil)
+        #expect(transportError?.recoverable == true)
+        #expect(transportError?.underlyingError is DummyError)
         await collector.events.expectNoEvent()
 
-        // The handler can force the same error to be terminal.
-        connectionErrorAction.value = .shutdown
-        #expect(!es.emitError(DummyError(), statusCode: nil, headers: [:]))
-        #expect(connectionErrorHandlerCallCount.value == 2)
-        #expect(await collector.expectError()?.recoverable == false)
+        // An unrecoverable HTTP status is reported as terminal, with its headers surfaced.
+        #expect(!es.emitError(statusCode: 401, headers: ["x-ld-fd-fallback": "poll"], underlyingError: nil))
+        let httpError = await collector.expectError()
+        #expect(httpError?.statusCode == 401)
+        #expect(httpError?.recoverable == false)
+        #expect(httpError?.headers["x-ld-fd-fallback"] == "poll")
 
         continuation.finish()
         await expectFullyConsumed(collector)
@@ -465,60 +455,6 @@ final class LDSwiftEventSourceTests {
     }
 #endif
 
-    @Test func shutdownByErrorHandlerOnInitialErrorResponse() async throws {
-        // The connectionErrorHandler runs on the URLSession delegate queue, off the test's
-        // task, so we capture what it observed and assert on the test thread.
-        let observedResponseCode = Box<Int?>(nil)
-        var config = EventSource.Config(url: URL(string: "http://example.com")!)
-        config.urlSessionConfiguration = sessionWithMockProtocol()
-        config.reconnectTime = 0.1
-        config.connectionErrorHandler = { err in
-            observedResponseCode.value = (err as? UnsuccessfulResponseError)?.responseCode
-            return .shutdown
-        }
-        let es = EventSource(config: config)
-        let collector = EventCollector(es.events)
-        es.start()
-        let handler = try #require(await MockingProtocol.requested.expectEvent())
-        handler.respond(statusCode: 400)
-        // 400 is recoverable by status, but the handler forces a terminal outcome: the error is reported
-        // as unrecoverable and the stream ends without a reconnect.
-        let err = await collector.expectError()
-        #expect(err?.statusCode == 400)
-        #expect(err?.recoverable == false)
-        await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
-        #expect(observedResponseCode.value == 400)
-        await expectFullyConsumed(collector)
-        collector.cancel()
-    }
-
-    @Test func shutdownByErrorHandlerOnResponseCompletionError() async throws {
-        var config = EventSource.Config(url: URL(string: "http://example.com")!)
-        config.urlSessionConfiguration = sessionWithMockProtocol()
-        config.reconnectTime = 0.1
-        config.connectionErrorHandler = { _ in
-            .shutdown
-        }
-        let es = EventSource(config: config)
-        let collector = EventCollector(es.events)
-        es.start()
-        let handler = try #require(await MockingProtocol.requested.expectEvent())
-        handler.respond(statusCode: 200)
-        await collector.expectOpened()
-        handler.finishWith(error: DummyError())
-        // A transport error after the connection opened; the handler forces it terminal, so it is
-        // reported as unrecoverable, followed by .closed, and the stream ends without a reconnect.
-        // (URLSession wraps the delegate error into an NSError on Darwin, so assert presence, not type.)
-        let err = await collector.expectError()
-        #expect(err?.recoverable == false)
-        #expect(err?.statusCode == nil)
-        #expect(err?.underlyingError != nil)
-        #expect(await collector.events.expectEvent() == .closed)
-        await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
-        await expectFullyConsumed(collector)
-        collector.cancel()
-    }
-
     @Test func shutdownBy204Response() async throws {
         var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()
@@ -535,31 +471,6 @@ final class LDSwiftEventSourceTests {
         #expect(err?.statusCode == 204)
         #expect(err?.recoverable == false)
         await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
-        await expectFullyConsumed(collector)
-        collector.cancel()
-    }
-
-    @Test func connectionErrorHandlerCanForceTerminal() async throws {
-        // 503 is normally recoverable; a connectionErrorHandler returning .shutdown overrides the
-        // default policy and makes the failure terminal (reported as unrecoverable, no reconnect).
-        let observedResponseCode = Box<Int?>(nil)
-        var config = EventSource.Config(url: URL(string: "http://example.com")!)
-        config.urlSessionConfiguration = sessionWithMockProtocol()
-        config.reconnectTime = 0.1
-        config.connectionErrorHandler = { err in
-            observedResponseCode.value = (err as? UnsuccessfulResponseError)?.responseCode
-            return .shutdown
-        }
-        let es = EventSource(config: config)
-        let collector = EventCollector(es.events)
-        es.start()
-        let handler = try #require(await MockingProtocol.requested.expectEvent())
-        handler.respond(statusCode: 503)
-        let err = await collector.expectError()
-        #expect(err?.statusCode == 503)
-        #expect(err?.recoverable == false)
-        await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
-        #expect(observedResponseCode.value == 503)
         await expectFullyConsumed(collector)
         collector.cancel()
     }

--- a/Tests/MockHandler.swift
+++ b/Tests/MockHandler.swift
@@ -3,6 +3,23 @@
 enum ReceivedEvent: Equatable {
     case opened, closed, message(String, MessageEvent), comment(String), error(Error)
 
+    /// Maps a public `EventSourceEvent` to the test-side enum so stream output can be
+    /// compared with the same `Equatable` the callback-based doubles use.
+    init(_ event: EventSourceEvent) {
+        switch event {
+        case .opened:
+            self = .opened
+        case .closed:
+            self = .closed
+        case let .message(eventType, messageEvent):
+            self = .message(eventType, messageEvent)
+        case let .comment(comment):
+            self = .comment(comment)
+        case let .error(error):
+            self = .error(error)
+        }
+    }
+
     static func == (lhs: ReceivedEvent, rhs: ReceivedEvent) -> Bool {
         switch (lhs, rhs) {
         case (.opened, .opened):

--- a/Tests/MockHandler.swift
+++ b/Tests/MockHandler.swift
@@ -1,14 +1,18 @@
 @testable import LDSwiftEventSource
 
 enum ReceivedEvent: Equatable {
-    case opened, closed, message(String, MessageEvent), comment(String), error(Error)
+    case opened(headers: [String: String])
+    case closed
+    case message(String, MessageEvent)
+    case comment(String)
+    case error(EventSourceError)
 
     /// Maps a public `EventSourceEvent` to the test-side enum so stream output can be
     /// compared with the same `Equatable` the callback-based doubles use.
     init(_ event: EventSourceEvent) {
         switch event {
-        case .opened:
-            self = .opened
+        case let .opened(headers):
+            self = .opened(headers: headers)
         case .closed:
             self = .closed
         case let .message(eventType, messageEvent):
@@ -23,6 +27,7 @@ enum ReceivedEvent: Equatable {
     static func == (lhs: ReceivedEvent, rhs: ReceivedEvent) -> Bool {
         switch (lhs, rhs) {
         case (.opened, .opened):
+            // Equality ignores headers; tests that care inspect them via EventCollector.expectOpened().
             return true
         case (.closed, .closed):
             return true
@@ -30,8 +35,9 @@ enum ReceivedEvent: Equatable {
             return typeLhs == typeRhs && eventLhs == eventRhs
         case let (.comment(lhs), .comment(rhs)):
             return lhs == rhs
-        case (.error, .error):
-            return true
+        case let (.error(lhs), .error(rhs)):
+            // Compare the load-bearing fields; underlyingError isn't Equatable.
+            return lhs.statusCode == rhs.statusCode && lhs.recoverable == rhs.recoverable
         default:
             return false
         }
@@ -41,9 +47,9 @@ enum ReceivedEvent: Equatable {
 final class MockHandler: EventHandler {
     let events = EventSink<ReceivedEvent>()
 
-    func onOpened() { events.record(.opened) }
+    func onOpened(headers: [String: String]) { events.record(.opened(headers: headers)) }
     func onClosed() { events.record(.closed) }
     func onMessage(eventType: String, messageEvent: MessageEvent) { events.record(.message(eventType, messageEvent)) }
     func onComment(comment: String) { events.record(.comment(comment)) }
-    func onError(error: Error) { events.record(.error(error)) }
+    func onError(_ error: EventSourceError) { events.record(.error(error)) }
 }

--- a/Tests/TestUtil.swift
+++ b/Tests/TestUtil.swift
@@ -6,57 +6,23 @@ import Testing
 import FoundationNetworking
 #endif
 
-// A thread-safe queue used to hand events from the background threads that drive
-// the mocks (the URLSession delegate queue, the URLProtocol loading thread) to the
-// test thread, which blocks waiting for them. A reference type guarded by an
-// `NSCondition` so it can be shared across those threads; `@unchecked Sendable`
-// because the locking the compiler cannot verify is what makes the access safe.
+// A thread-safe FIFO recorder for the synchronous parser tests, where events are produced (via
+// MockHandler) and drained on the same test thread. `@unchecked Sendable` with an `NSLock` so
+// MockHandler can stay `Sendable`; tests pull with the non-blocking `maybeEvent()`.
 final class EventSink<T>: @unchecked Sendable {
-    private let condition = NSCondition()
+    private let lock = NSLock()
     private var receivedEvents: [T] = []
 
     func record(_ event: T) {
-        condition.lock()
-        defer { condition.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
         receivedEvents.append(event)
-        condition.signal()
-    }
-
-    func expectEvent(maxWait: TimeInterval = 1.0) -> T {
-        let deadline = Date(timeIntervalSinceNow: maxWait)
-        condition.lock()
-        defer { condition.unlock() }
-        while receivedEvents.isEmpty {
-            guard condition.wait(until: deadline)
-            else {
-                Issue.record("Expected mock handler to be called")
-                return (nil as T?)!
-            }
-        }
-        return receivedEvents.removeFirst()
     }
 
     func maybeEvent() -> T? {
-        condition.lock()
-        defer { condition.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
         return receivedEvents.isEmpty ? nil : receivedEvents.removeFirst()
-    }
-
-    func expectNoEvent(within: TimeInterval = 0.1) {
-        let deadline = Date(timeIntervalSinceNow: within)
-        condition.lock()
-        defer { condition.unlock() }
-        while receivedEvents.isEmpty {
-            guard condition.wait(until: deadline)
-            else { return }
-        }
-        Issue.record("Expected no events in sink, found \(String(describing: receivedEvents.first))")
-    }
-
-    func reset() {
-        condition.lock()
-        defer { condition.unlock() }
-        receivedEvents.removeAll()
     }
 }
 
@@ -92,8 +58,10 @@ final class AsyncSink<T>: @unchecked Sendable {
         return maybeEvent()
     }
 
-    /// Asserts that no event arrives within `within`.
-    func expectNoEvent(within: Duration = .milliseconds(100)) async {
+    /// Asserts that no event arrives within `within`. The window is a safety margin against an event
+    /// that is in flight but not yet recorded; prefer `EventCollector.drained()` + `maybeEvent()` when
+    /// the stream has already finished, which is deterministic.
+    func expectNoEvent(within: Duration = .milliseconds(250)) async {
         try? await Task.sleep(for: within)
         if let event = maybeEvent() {
             Issue.record("Expected no events in sink, found \(String(describing: event))")
@@ -121,6 +89,14 @@ final class EventCollector: Sendable {
                 sink.record(ReceivedEvent(event))
             }
         }
+    }
+
+    /// Awaits the drain task, which finishes once the source stream finishes (e.g. after `stop()`).
+    /// Once this returns, every event the stream produced has been recorded, so the sink can be
+    /// checked synchronously with `maybeEvent()` — no timing window. Only call this when the stream is
+    /// expected to finish, or it will await indefinitely.
+    func drained() async {
+        await task.value
     }
 
     func cancel() {
@@ -156,7 +132,9 @@ final class RequestHandler {
     let request: URLRequest
     let client: URLProtocolClient?
 
-    var stopped = false
+    // Set when the URLProtocol's stopLoading runs (i.e. the connection was torn down). Lock-protected
+    // because it is written on the loading thread and read from the test thread.
+    let stopped = Box(false)
 
     init(proto: URLProtocol, request: URLRequest, client: URLProtocolClient?) {
         self.proto = proto
@@ -187,7 +165,7 @@ final class RequestHandler {
     }
 
     func stop() {
-        stopped = true
+        stopped.value = true
     }
 }
 

--- a/Tests/TestUtil.swift
+++ b/Tests/TestUtil.swift
@@ -124,9 +124,9 @@ final class EventCollector: Sendable {
     }
 }
 
-// A lock-protected reference cell so tests can read and mutate a value from inside
-// the `@Sendable` configuration closures (e.g. connectionErrorHandler) without
-// tripping the concurrent-capture checks of the v6 language mode.
+// A lock-protected reference cell for state that is written and read across threads (e.g. a flag set
+// on the URLProtocol loading thread and checked from the test thread), without tripping the v6
+// language mode's concurrent-capture checks.
 final class Box<T>: @unchecked Sendable {
     private let lock = NSLock()
     private var storedValue: T

--- a/Tests/TestUtil.swift
+++ b/Tests/TestUtil.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+@testable import LDSwiftEventSource
 
 #if os(Linux) || os(Windows)
 import FoundationNetworking
@@ -56,6 +57,74 @@ final class EventSink<T>: @unchecked Sendable {
         condition.lock()
         defer { condition.unlock() }
         receivedEvents.removeAll()
+    }
+}
+
+// Poll-based, non-blocking sibling of `EventSink` for async tests. `record(_:)` is
+// safe to call from any thread (the URLProtocol loading thread, the URLSession
+// delegate queue, or a drain Task); the `expect*` methods are async and never block a
+// thread, so they are safe to await on swift-testing's cooperative executor.
+final class AsyncSink<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var receivedEvents: [T] = []
+
+    func record(_ event: T) {
+        lock.lock()
+        defer { lock.unlock() }
+        receivedEvents.append(event)
+    }
+
+    func maybeEvent() -> T? {
+        lock.lock()
+        defer { lock.unlock() }
+        return receivedEvents.isEmpty ? nil : receivedEvents.removeFirst()
+    }
+
+    /// Polls up to `within` for an event, returning nil if none arrives in time.
+    func expectEvent(within: Duration = .seconds(1)) async -> T? {
+        let deadline = ContinuousClock.now + within
+        while ContinuousClock.now < deadline {
+            if let event = maybeEvent() {
+                return event
+            }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return maybeEvent()
+    }
+
+    /// Asserts that no event arrives within `within`.
+    func expectNoEvent(within: Duration = .milliseconds(100)) async {
+        try? await Task.sleep(for: within)
+        if let event = maybeEvent() {
+            Issue.record("Expected no events in sink, found \(String(describing: event))")
+        }
+    }
+
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        receivedEvents.removeAll()
+    }
+}
+
+// Drains an `EventSource`'s event stream into an `AsyncSink` for assertions, mapping
+// each `EventSourceEvent` to a `ReceivedEvent` (whose `Equatable` treats all errors as
+// equal). The draining task runs until the stream finishes or `cancel()` is called.
+final class EventCollector: Sendable {
+    let events = AsyncSink<ReceivedEvent>()
+    private let task: Task<Void, Never>
+
+    init(_ source: AsyncStream<EventSourceEvent>) {
+        let sink = events
+        task = Task {
+            for await event in source {
+                sink.record(ReceivedEvent(event))
+            }
+        }
+    }
+
+    func cancel() {
+        task.cancel()
     }
 }
 
@@ -127,7 +196,7 @@ class MockingProtocol: URLProtocol {
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canInit(with task: URLSessionTask) -> Bool { true }
 
-    static let requested = EventSink<RequestHandler>()
+    static let requested = AsyncSink<RequestHandler>()
 
     class func resetRequested() {
         requested.reset()

--- a/Tests/TestUtil.swift
+++ b/Tests/TestUtil.swift
@@ -91,6 +91,26 @@ final class EventCollector: Sendable {
         }
     }
 
+    /// Asserts the next event is `.opened`, returning its headers (records an issue and returns nil otherwise).
+    @discardableResult
+    func expectOpened(within: Duration = .seconds(1)) async -> [String: String]? {
+        guard case let .opened(headers)? = await events.expectEvent(within: within) else {
+            Issue.record("Expected an .opened event")
+            return nil
+        }
+        return headers
+    }
+
+    /// Asserts the next event is `.error`, returning it (records an issue and returns nil otherwise).
+    @discardableResult
+    func expectError(within: Duration = .seconds(1)) async -> EventSourceError? {
+        guard case let .error(error)? = await events.expectEvent(within: within) else {
+            Issue.record("Expected an .error event")
+            return nil
+        }
+        return error
+    }
+
     /// Awaits the drain task, which finishes once the source stream finishes (e.g. after `stop()`).
     /// Once this returns, every event the stream produced has been recorded, so the sink can be
     /// checked synchronously with `maybeEvent()` — no timing window. Only call this when the stream is
@@ -142,8 +162,9 @@ final class RequestHandler {
         self.client = client
     }
 
-    func respond(statusCode: Int) {
-        let headers = ["Content-Type": "text/event-stream; charset=utf-8", "Transfer-Encoding": "chunked"]
+    func respond(statusCode: Int, headers extraHeaders: [String: String] = [:]) {
+        var headers = ["Content-Type": "text/event-stream; charset=utf-8", "Transfer-Encoding": "chunked"]
+        headers.merge(extraHeaders) { _, new in new }
         let resp = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: headers)!
         client?.urlProtocol(proto, didReceive: resp, cacheStoragePolicy: .notAllowed)
     }


### PR DESCRIPTION
Phase 2 of the Swift 6 modernization (SDK-2607). Replaces the push-based
EventHandler callback with an AsyncStream of events that consumers iterate with
`for await`. This is the surface the swift-core streaming FDv2Synchronizer
(Phase 3) needs; an AsyncStream maps almost 1:1 onto its `next() async`.

BREAKING CHANGE: EventHandler is no longer public and EventSource.Config no
longer takes a handler. Consume `EventSource.events` instead.

Public API:
- Add `EventSourceEvent` (opened / closed / message / comment / error).
- `EventSource.events` exposes an `AsyncStream<EventSourceEvent>`; `Config.init`
  drops the `handler` parameter (now just `init(url:)`).
- Errors are delivered as `.error` values, not stream terminations: the client
  keeps retrying with backoff and the stream continues, ending only on stop()
  (or consumer cancellation). Lifecycle stays explicit via start()/stop().

Internal:
- EventHandler becomes internal; EventParser still drives it. A private
  ContinuationEventHandler forwards the delegate's and parser's callbacks into
  the stream's continuation. The URLSessionDataDelegate data path is unchanged
  (no URLSession.bytes, which is unavailable on Linux/Windows Foundation).
- The delegate finishes the continuation at terminal shutdown; the consumer
  cancelling iteration tears the connection down via onTermination.

Tests / contract service:
- Network tests become async and observe events via a non-blocking poll-based
  AsyncSink drained from the stream (no thread blocking on the cooperative
  executor); the suite stays .serialized for the global URLProtocol state. The
  parser tests keep the synchronous EventSink. Buffering is .unbounded.
- Contract test service consumes `events` in a Task and forwards to the callback
  URL instead of implementing EventHandler.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Major breaking public API change and rework of connection error/reconnect semantics; downstream SDKs must migrate from callbacks to stream iteration and new error handling.
> 
> **Overview**
> **BREAKING:** The public API no longer uses a push `EventHandler` or `Config(handler:url:)`. Consumers iterate **`EventSource.events`** (`AsyncStream<EventSourceEvent>`) after `start()`, with `Config` initialized via **`init(url:)`** only.
> 
> New stream types **`EventSourceEvent`** (including **`.opened(headers:)`**) and **`EventSourceError`** (status, lowercased headers, **`recoverable`**, optional underlying transport error). Failures are **`.error` values** on the stream—recoverable errors keep retrying; unrecoverable ones finish the stream. **`ConnectionErrorHandler`**, **`UnsuccessfulResponseError`**, and configurable shutdown via error handler are removed in favor of built-in status classification (5xx, 400, 408, 429 recoverable; others terminal). **`stop()`**, consumer cancellation, and **`onTermination`** finish the stream and tear down the connection.
> 
> README adds **Usage** with a `for await` example. The contract test service drains **`events`** in a **`Task`** via **`CallbackForwarder`** instead of implementing **`EventHandler`**. Tests are async, use **`EventCollector`** / **`AsyncSink`**, and cover headers, reconnect continuity, and cancellation teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3d02bee064c7554593ff1d4dcace4fb6ae305a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->