### PR TITLE
chore: Lower minimum platform versions to the Xcode 26 floor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
     name: "LDSwiftEventSource",
     platforms: [
-        .iOS(.v16),
-        .macOS(.v13),
-        .tvOS(.v16),
-        .watchOS(.v9),
+        .iOS(.v15),
+        .macOS(.v11),
+        .tvOS(.v15),
+        .watchOS(.v8),
     ],
     products: [
         .library(name: "LDSwiftEventSource", targets: ["LDSwiftEventSource"]),

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 LDSwiftEventSource is a cross platform implementation of the [EventSource specification](https://html.spec.whatwg.org/multipage/server-sent-events.html) written in Swift. It was developed for use in the [LaunchDarkly iOS SDK](https://github.com/launchdarkly/ios-client-sdk). Generated API docs are available on [GitHub Pages](https://launchdarkly.github.io/swift-eventsource/).
 
 ## Requirements
-- iOS 16.0+ / watchOS 9.0+ / tvOS 16.0+ / macOS 13.0+
+- iOS 15.0+ / watchOS 8.0+ / tvOS 15.0+ / macOS 11.0+
 - Swift 6.0+
 
 ## Installation

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -357,9 +357,9 @@ final class LDSwiftEventSourceTests {
         // Cancelling the only consumer fires the stream's onTermination, which tears the connection
         // down (no explicit stop()). The mock observes this as stopLoading -> RequestHandler.stop().
         collector.cancel()
-        let deadline = ContinuousClock.now + .seconds(1)
-        while ContinuousClock.now < deadline && !handler.stopped.value {
-            try? await Task.sleep(for: .milliseconds(5))
+        let deadline = Date(timeIntervalSinceNow: 1.0)
+        while Date() < deadline && !handler.stopped.value {
+            try? await Task.sleep(nanoseconds: 5_000_000) // 5ms
         }
         #expect(handler.stopped.value)
     }
@@ -424,7 +424,7 @@ final class LDSwiftEventSourceTests {
         #expect(err?.statusCode == 401)
         #expect(err?.recoverable == false)
         #expect(err?.headers["x-ld-fd-fallback"] == "poll")
-        await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
+        await MockingProtocol.requested.expectNoEvent(within: 1.0)
         await expectFullyConsumed(collector)
         collector.cancel()
     }
@@ -470,7 +470,7 @@ final class LDSwiftEventSourceTests {
         let err = await collector.expectError()
         #expect(err?.statusCode == 204)
         #expect(err?.recoverable == false)
-        await MockingProtocol.requested.expectNoEvent(within: .seconds(1))
+        await MockingProtocol.requested.expectNoEvent(within: 1.0)
         await expectFullyConsumed(collector)
         collector.cancel()
     }

--- a/Tests/TestUtil.swift
+++ b/Tests/TestUtil.swift
@@ -46,23 +46,25 @@ final class AsyncSink<T>: @unchecked Sendable {
         return receivedEvents.isEmpty ? nil : receivedEvents.removeFirst()
     }
 
-    /// Polls up to `within` for an event, returning nil if none arrives in time.
-    func expectEvent(within: Duration = .seconds(1)) async -> T? {
-        let deadline = ContinuousClock.now + within
-        while ContinuousClock.now < deadline {
+    /// Polls up to `within` seconds for an event, returning nil if none arrives in time.
+    /// Uses `Date`/`Task.sleep(nanoseconds:)` rather than `ContinuousClock`/`Duration` so the tests
+    /// compile at the package's minimum deployment targets (Clock/Duration require iOS 16 / macOS 13).
+    func expectEvent(within: TimeInterval = 1.0) async -> T? {
+        let deadline = Date(timeIntervalSinceNow: within)
+        while Date() < deadline {
             if let event = maybeEvent() {
                 return event
             }
-            try? await Task.sleep(for: .milliseconds(5))
+            try? await Task.sleep(nanoseconds: 5_000_000) // 5ms
         }
         return maybeEvent()
     }
 
-    /// Asserts that no event arrives within `within`. The window is a safety margin against an event
-    /// that is in flight but not yet recorded; prefer `EventCollector.drained()` + `maybeEvent()` when
-    /// the stream has already finished, which is deterministic.
-    func expectNoEvent(within: Duration = .milliseconds(250)) async {
-        try? await Task.sleep(for: within)
+    /// Asserts that no event arrives within `within` seconds. The window is a safety margin against an
+    /// event that is in flight but not yet recorded; prefer `EventCollector.drained()` + `maybeEvent()`
+    /// when the stream has already finished, which is deterministic.
+    func expectNoEvent(within: TimeInterval = 0.25) async {
+        try? await Task.sleep(nanoseconds: UInt64(within * 1_000_000_000))
         if let event = maybeEvent() {
             Issue.record("Expected no events in sink, found \(String(describing: event))")
         }
@@ -93,7 +95,7 @@ final class EventCollector: Sendable {
 
     /// Asserts the next event is `.opened`, returning its headers (records an issue and returns nil otherwise).
     @discardableResult
-    func expectOpened(within: Duration = .seconds(1)) async -> [String: String]? {
+    func expectOpened(within: TimeInterval = 1.0) async -> [String: String]? {
         guard case let .opened(headers)? = await events.expectEvent(within: within) else {
             Issue.record("Expected an .opened event")
             return nil
@@ -103,7 +105,7 @@ final class EventCollector: Sendable {
 
     /// Asserts the next event is `.error`, returning it (records an issue and returns nil otherwise).
     @discardableResult
-    func expectError(within: Duration = .seconds(1)) async -> EventSourceError? {
+    func expectError(within: TimeInterval = 1.0) async -> EventSourceError? {
         guard case let .error(error)? = await events.expectEvent(within: within) else {
             Issue.record("Expected an .error event")
             return nil


### PR DESCRIPTION
Drop the deployment minimums from iOS 16 / macOS 13 / tvOS 16 / watchOS 9 (which
matched swift-core) to iOS 15 / macOS 11 / tvOS 15 / watchOS 8. The library uses
no API gated above this floor (AsyncStream + makeStream + Continuation are iOS 13
/ macOS 10.15; tlsMinimumSupportedProtocolVersion is iOS 13), so a dependency can
sit below its consumers.

The only thing pinning the old floor was test-side timing: the AsyncSink helper
used the Clock/Duration family (ContinuousClock, Duration, Task.sleep(for:)),
which requires iOS 16 / macOS 13 (SE-0329). Reworked it to Date deadlines +
Task.sleep(nanoseconds:), which are available at the new floor.

- Package.swift: platforms -> iOS 15 / macOS 11 / tvOS 15 / watchOS 8.
- TestUtil: AsyncSink.expectEvent/expectNoEvent and EventCollector helpers take
  a TimeInterval and poll/sleep via Date + nanoseconds instead of Clock/Duration.
- Update the cancellation-teardown test's poll loop the same way.
- README: update the Requirements line.

The Apple-availability of makeStream and swift-testing at the new floor is
verified by CI (build-apple across the four platforms + test-macos), which build
at the lowered deployment targets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No production code changes—only Package.swift platforms, README, and test utilities; slightly wider OS support with equivalent test behavior.
> 
> **Overview**
> **Lowers SwiftPM deployment minimums** so dependents can target older OS versions: iOS 15, macOS 11, tvOS 15, and watchOS 8 (down from iOS 16 / macOS 13 / tvOS 16 / watchOS 9). `README` requirements are updated to match.
> 
> **Test timing helpers** no longer use `ContinuousClock`, `Duration`, or `Task.sleep(for:)`, which need iOS 16 / macOS 13+. `AsyncSink` / `EventCollector` now take `TimeInterval` and poll with `Date` deadlines and `Task.sleep(nanoseconds:)`. Call sites in `LDSwiftEventSourceTests` (including the consumer-cancellation poll loop and `expectNoEvent` windows) follow the same pattern.
> 
> Library implementation is unchanged; the previous floor was driven by test-only APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f63241db832e4c842f48fd99ba50f001edc08151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->