### PR TITLE
fix: Guard EventParser.lastEventId against a data race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,20 @@ jobs:
 
       - uses: ./.github/actions/test-swiftpm
 
+  test-thread-sanitizer:
+    runs-on: ubuntu-latest
+    container: swift:6.1
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test with ThreadSanitizer
+        # halt_on_error makes a detected data race abort with a non-zero exit so the job fails;
+        # without it TSan only prints a warning and the step would stay green.
+        env:
+          TSAN_OPTIONS: halt_on_error=1
+        run: swift test --sanitize=thread
+
   contract-tests:
     runs-on: macos-15
 

--- a/Source/EventParser.swift
+++ b/Source/EventParser.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-class EventParser {
+// `parse`, `reset`, and event dispatch must be driven from a single serialized context (the
+// EventSource delegate queue). `getLastEventId()` is the one entry point called concurrently — from
+// arbitrary caller threads via `EventSource.getLastEventId()` — so the `lastEventId` it reads is
+// lock-guarded. `@unchecked Sendable` reflects that split, which the compiler cannot verify.
+final class EventParser: @unchecked Sendable {
     private struct Constants {
         static let dataLabel: Substring = "data"
         static let idLabel: Substring = "id"
@@ -13,12 +17,28 @@ class EventParser {
     private var data: String = ""
     private var eventType: String = ""
     private var lastEventIdBuffer: String?
-    private var lastEventId: String
     private var currentRetry: TimeInterval
+
+    // Written on the serialized parse path and read from any thread via `getLastEventId()`, so its
+    // access is guarded by a lock.
+    private let lastEventIdLock = NSLock()
+    private var _lastEventId: String
+    private var lastEventId: String {
+        get {
+            lastEventIdLock.lock()
+            defer { lastEventIdLock.unlock() }
+            return _lastEventId
+        }
+        set {
+            lastEventIdLock.lock()
+            defer { lastEventIdLock.unlock() }
+            _lastEventId = newValue
+        }
+    }
 
     init(handler: EventHandler, initialEventId: String, initialRetry: TimeInterval) {
         self.handler = handler
-        self.lastEventId = initialEventId
+        self._lastEventId = initialEventId
         self.currentRetry = initialRetry
     }
 

--- a/Tests/EventParserTests.swift
+++ b/Tests/EventParserTests.swift
@@ -306,4 +306,30 @@ final class EventParserTests {
         #expect(handler.events.maybeEvent() == .comment("bar"))
         #expect(handler.events.maybeEvent() == .message("msg", MessageEvent(data: "foo", lastEventId: "")))
     }
+
+    // MARK: Concurrency
+    // getLastEventId() is read from arbitrary threads while events are parsed on another; the read
+    // must be race-free. Uses a local parser/handler (not the suite fixtures) so the concurrent
+    // writes don't trip the deinit "no leftover events" check. Run under `--sanitize=thread` to
+    // actually catch a regression here.
+    @Test func getLastEventIdIsSafeDuringConcurrentParsing() async {
+        let parser = EventParser(handler: MockHandler(), initialEventId: "", initialRetry: 1.0)
+        await withTaskGroup(of: Void.self) { group in
+            // Writer: drive events on a single task, mirroring the serialized delegate queue.
+            group.addTask {
+                for id in 0..<2000 {
+                    parser.parse(line: "id: \(id)")
+                    parser.parse(line: "data: x")
+                    parser.parse(line: "")
+                }
+            }
+            // Reader: hammer getLastEventId() from a separate task, concurrent with the writer.
+            group.addTask {
+                for _ in 0..<2000 {
+                    _ = parser.getLastEventId()
+                }
+            }
+        }
+        #expect(parser.getLastEventId() == "1999")
+    }
 }


### PR DESCRIPTION
getLastEventId() reads EventParser.lastEventId from arbitrary caller threads (via
EventSource.getLastEventId()), while it is written on the serialized delegate
queue during event dispatch. Reading a String concurrently with a write is
undefined behavior (a torn copy-on-write buffer), not merely a stale value; the
@unchecked Sendable delegate suppressed the compiler check.

Guard the field with an NSLock: lastEventId is now a computed property whose get
and set lock a private backing store, so the cross-thread read is safe regardless
of the writing thread. parse()/reset()/dispatch remain serialized on the delegate
queue and are unchanged. Mark EventParser @unchecked Sendable to document that
split (serialized mutation + lock-guarded cross-thread read).

Adds a concurrency test that hammers getLastEventId() from one task while another
drives events, asserting correctness under load. Run under `--sanitize=thread` to
catch a regression (TSan is unavailable on the Linux toolchain here; the macOS CI
leg is TSan-capable).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path SSE state read from arbitrary threads; the lock is narrow but incorrect locking could still affect reconnect `Last-Event-Id` behavior under load.
> 
> **Overview**
> Fixes a **data race** on `EventParser.lastEventId`: `getLastEventId()` can run on caller threads (via `EventSource`) while dispatch updates the field on the serialized delegate queue. Concurrent `String` read/write is undefined behavior, not just stale values.
> 
> **`lastEventId`** is now backed by `_lastEventId` behind an **`NSLock`** via a computed property; parse/reset/dispatch stay on the delegate queue. **`EventParser`** is **`@unchecked Sendable`** with comments describing that split.
> 
> Adds **`getLastEventIdIsSafeDuringConcurrentParsing`** (writer parses events, reader hammers `getLastEventId()`). CI gains **`test-thread-sanitizer`** on Ubuntu (`swift:6.1`) running `swift test --sanitize=thread` with **`TSAN_OPTIONS=halt_on_error=1`** so races fail the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efa6dafe7329bc6c961509f2bd8f99dbae4e32bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->