### PR TITLE
fix: Emit an error when the stream closes before any response

### DIFF
--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -333,6 +333,17 @@ final class EventSourceDelegate: NSObject, URLSessionDataDelegate, @unchecked Se
                     return
                 }
             }
+        } else if readyState != .open {
+            // The task completed with no error, but the stream never opened -- no usable HTTP response
+            // was delivered. On Linux, libcurl terminates a 3xx redirect with an empty or missing
+            // Location exactly this way (no error, no response, no willPerformHTTPRedirection call),
+            // whereas CFNetwork surfaces it as an error. Retrying the same URL just repeats it, so
+            // report an unrecoverable error and stop instead of reconnecting forever.
+            logger.info("Connection closed before any response was received; reporting as unrecoverable")
+            handler.onError(EventSourceError(statusCode: nil, headers: [:], recoverable: false, underlyingError: nil))
+            readyState = .shutdown
+            continuation.finish()
+            return
         } else {
             logger.info("Connection unexpectedly closed.")
         }

--- a/Tests/LDSwiftEventSourceTests.swift
+++ b/Tests/LDSwiftEventSourceTests.swift
@@ -281,6 +281,28 @@ final class LDSwiftEventSourceTests {
         collector.cancel()
     }
 
+    @Test func closeWithoutResponseEmitsUnrecoverableError() async throws {
+        var config = EventSource.Config(url: URL(string: "http://example.com")!)
+        config.urlSessionConfiguration = sessionWithMockProtocol()
+        config.reconnectTime = 0.1
+        let es = EventSource(config: config)
+        let collector = EventCollector(es.events)
+        es.start()
+        let handler = try #require(await MockingProtocol.requested.expectEvent())
+        // Finish the request without ever sending a response. This is how libcurl (Linux) terminates a
+        // 3xx redirect whose Location is empty or missing: the task completes with no error and no
+        // response. The client must surface an unrecoverable error and stop, not reconnect forever.
+        handler.finish()
+        let error = await collector.expectError()
+        #expect(error?.statusCode == nil)
+        #expect(error?.recoverable == false)
+        // The unrecoverable error ends the stream; no reconnect attempt should follow.
+        await MockingProtocol.requested.expectNoEvent()
+        es.stop()
+        await expectFullyConsumed(collector)
+        collector.cancel()
+    }
+
     @Test func lastEventIdUpdatedByEvents() async throws {
         var config = EventSource.Config(url: URL(string: "http://example.com")!)
         config.urlSessionConfiguration = sessionWithMockProtocol()


### PR DESCRIPTION
On Linux, swift-corelibs-foundation (libcurl) terminates a 3xx redirect with an
empty or missing Location header by completing the task with no error and no
response -- no didReceive, no willPerformHTTPRedirection callback. EventSource
treated that as a normal close and reconnected forever, never emitting an error,
so the SSE contract tests "client handles empty/missing Location header with
301/307 status" timed out. (CFNetwork surfaces it as an error, so macOS passed.)

Treat a no-error completion that never opened the stream as an unrecoverable
error and stop, giving deterministic behavior across platforms. Adds a
regression test that finishes a request with no response and asserts an
unrecoverable error with no reconnect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection teardown in `didCompleteWithError` for a narrow edge case; misclassification could stop valid reconnects or still loop, but scope is limited to tasks that never reached `.open`.
> 
> **Overview**
> Fixes **infinite reconnect** when a URLSession task completes successfully but never delivers headers (so `readyState` never becomes `.open`). On Linux/libcurl this happens for **3xx redirects with empty or missing `Location`**; macOS often reports an error instead.
> 
> In `urlSession(_:task:didCompleteWithError:)`, a new branch treats **no error + never opened** as an **unrecoverable** `EventSourceError`, sets **shutdown**, finishes the stream, and **skips** the reconnect loop.
> 
> Adds **`closeWithoutResponseEmitsUnrecoverableError`** to finish a mock request without responding and assert a non-recoverable error with no follow-up request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71de07743d80ff37d71ba98be6caf1398c708e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->