### PR TITLE
ci: Run contract tests on Linux as well as macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,34 @@ jobs:
         run: swift test --sanitize=thread
 
   contract-tests:
-    runs-on: macos-15
+    name: 'contract-tests (${{ matrix.name }})'
+    runs-on: ${{ matrix.os }}
+    # Empty for the macOS job, which runs directly on the runner VM.
+    container: ${{ matrix.container }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macos
+            os: macos-15
+          - name: linux
+            os: ubuntu-latest
+            container: swift:6.1
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd
+      - name: Select Xcode
+        if: runner.os == 'macOS'
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd
         with:
           xcode-version: 16.4
+
+      # The swift container lacks make (the composite action) and curl (the harness downloader).
+      - name: Install make and curl
+        if: runner.os == 'Linux'
+        run: apt-get update && apt-get install -y make curl
 
       - uses: ./.github/actions/contract-tests
         with:


### PR DESCRIPTION
Now that ContractTestService builds on Linux (Hummingbird, SDK-2666) and the SDK
handles empty/missing-Location redirects correctly there (SDK-2676), run the
contract suite on Linux too. Convert contract-tests to a macOS + Linux matrix
(fail-fast: false). Linux runs in the swift:6.1 container and installs make (used
by the composite action) and curl (used by the harness downloader), both absent
from the image. macOS is unchanged (macos-15 / Xcode 16.4).

Windows is intentionally excluded: the service's server framework (Hummingbird /
swift-nio) has no Windows support; the SDK itself is covered on Windows by the
existing test-windows unit-test job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes with no application, auth, or data-path impact; Linux adds container deps so existing composite contract-test steps can run.
> 
> **Overview**
> **Expands the `contract-tests` CI job** from macOS-only to a **macOS + Linux matrix** (`fail-fast: false`), so the same contract suite runs on `ubuntu-latest` inside `swift:6.1` in addition to unchanged `macos-15` / Xcode 16.4.
> 
> On Linux, the workflow **installs `make` and `curl`** before the composite action (missing from the Swift image but required by `make build-contract-tests` / the harness downloader). **Xcode setup is gated** to macOS only; job names are **`contract-tests (${{ matrix.name }})`** for clearer matrix reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a883c54f40becec4246d3ab4f6cf6b736382edd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->